### PR TITLE
Metro API v2.1.3 The "Rail-y Big" End-Point Update

### DIFF
--- a/data-loading-service/app/config.py
+++ b/data-loading-service/app/config.py
@@ -17,7 +17,7 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.1.2"
+    CURRENT_VERSION = "2.1.3"
     # API_LAST_UPDATE_TIME = os.path.getmtime(r'main.py')
     LOGZIO_TOKEN = os.environ.get('LOGZIO_TOKEN')
     LOGZIO_URL = os.environ.get('LOGZIO_URL')

--- a/data-loading-service/app/models/gtfs_rt.py
+++ b/data-loading-service/app/models/gtfs_rt.py
@@ -13,11 +13,11 @@ GTFSrtBase = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
 
 class TripUpdate(GTFSrtBase):
     __tablename__ = 'trip_updates'
-    oid = Column(Integer, primary_key=True)
+    # oid = Column(Integer, primary_key=True)
 
     # This replaces the TripDescriptor message
     # TODO: figure out the relations
-    trip_id = Column(String(64))
+    trip_id = Column(String(64), primary_key=True)
     route_id = Column(String(64))
     start_time = Column(String(8))
     start_date = Column(String(10))
@@ -29,7 +29,7 @@ class TripUpdate(GTFSrtBase):
     agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
-    # StopTimeUpdates = relationship('StopTimeUpdate', backref='TripUpdate')
+    stop_time_updates = relationship('StopTimeUpdate', backref=backref('trip_updates',lazy="joined"))
     class Config:
         schema_extra = {
             "definition": {
@@ -46,14 +46,14 @@ class StopTimeUpdate(GTFSrtBase):
     # oid = Column(Integer, )
 
     # TODO: Fill one from the other
-    stop_sequence = Column(Integer)
+    # stop_sequence = Column(Integer)
     stop_id = Column(String(10),primary_key=True)
     agency_id = Column(String)
     
     # TODO: Add domain
     schedule_relationship = Column(String(9))
     # Link it to the TripUpdate
-    # trip_update_id = Column(Integer, ForeignKey('trip_updates.oid'))
+    trip_id = Column(String, ForeignKey('trip_updates.trip_id'))
 
 class VehiclePosition(GTFSrtBase):
     __tablename__ = "vehicle_position_updates"

--- a/data-loading-service/app/models/gtfs_rt.py
+++ b/data-loading-service/app/models/gtfs_rt.py
@@ -25,7 +25,8 @@ class TripUpdate(GTFSrtBase):
     # TODO: add a domain
     schedule_relationship = Column(String(9))
     direction_id = Column(Integer)
-    
+
+    agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
     # StopTimeUpdates = relationship('StopTimeUpdate', backref='TripUpdate')
@@ -47,7 +48,8 @@ class StopTimeUpdate(GTFSrtBase):
     # TODO: Fill one from the other
     stop_sequence = Column(Integer)
     stop_id = Column(String(10),primary_key=True)
-
+    agency_id = Column(String)
+    
     # TODO: Add domain
     schedule_relationship = Column(String(9))
     # Link it to the TripUpdate
@@ -76,6 +78,7 @@ class VehiclePosition(GTFSrtBase):
     # collapsed Vehicle.Vehicle
     vehicle_id = Column(String,primary_key=True)
     vehicle_label = Column(String)
+    agency_id = Column(String)
 
     timestamp = Column(Integer)
 

--- a/data-loading-service/app/utils/gtfs_rt_helper.py
+++ b/data-loading-service/app/utils/gtfs_rt_helper.py
@@ -15,6 +15,7 @@ import pandas as pd
 
 import timeit
 from datetime import datetime
+from soupsieve import match
 from sqlalchemy.orm import Session,sessionmaker
 from sqlalchemy import create_engine, inspect
 from models.gtfs_rt import *
@@ -46,9 +47,11 @@ SWIFTLY_GTFS_RT_VEHICLE_POSITIONS = 'gtfs-rt-vehicle-positions'
 # session = Session()
 
 SERVICE_DICT = {
-    'bus': 'lametro',
-    'rail': 'lametro-rail'
+    'LACMTA': 'lametro',
+    'LACMTA_Rail': 'lametro-rail'
 }
+
+SWIFTLY_AGENCY_IDS = ['LACMTA', 'LACMTA_Rail']
 
 # Connect to the database
 def connect_to_db():
@@ -64,12 +67,11 @@ def connect_to_db():
 
 def connect_to_swiftly(service, endpoint):
     swiftly_endpoint = ''
+    swiftly_endpoint = SWIFTLY_API_REALTIME + service + '/' + endpoint
 
-    swiftly_endpoint = SWIFTLY_API_REALTIME + SERVICE_DICT[service] + '/' + endpoint
-
-    if (service == 'bus'):
+    if (service == 'lametro'):
         key = Config.SWIFTLY_AUTH_KEY_BUS
-    elif (service == 'rail'):
+    elif (service == 'lametro-rail'):
         key = Config.SWIFTLY_AUTH_KEY_RAIL
     header = { 
         "Authorization": key
@@ -83,66 +85,85 @@ def connect_to_swiftly(service, endpoint):
         print.exception('Error connecting to Swiftly API: ' + str(e))
         return
 
+def get_agency_id(service):
+    if (service == 'bus'):
+        return 'LACMTA'
+    elif (service == 'rail'):
+        return 'LACMTA_Rail'
+
 def update_gtfs_realtime_data():
     process_start = timeit.default_timer()
     connect_to_db()
+    combined_trip_update_dataframes = []
+    combined_stop_time_dataframes = []
+    combined_vehicle_position_dataframes = []
 
-    feed = FeedMessage()
-    response_data = connect_to_swiftly('bus', SWIFTLY_GTFS_RT_TRIP_UPDATES)
-    feed.ParseFromString(response_data)
-    
-    trip_update_array = []
-    stop_time_array = []
-    vehicle_position_update_array = []
-    for entity in feed.entity:
-        trip_update_array.append({
-            'trip_id': entity.trip_update.trip.trip_id,
-            'route_id': entity.trip_update.trip.route_id,
-            'start_time': entity.trip_update.trip.start_time,
-            'start_date': entity.trip_update.trip.start_date,
-            'direction_id': entity.trip_update.trip.direction_id,
-            'schedule_relationship': entity.trip_update.trip.schedule_relationship,
-            'timestamp': entity.trip_update.timestamp
-        })
-        for stop_time_update in entity.trip_update.stop_time_update:
-            stop_time_array.append({
+    for agency in SWIFTLY_AGENCY_IDS:
+        feed = FeedMessage()
+        response_data = connect_to_swiftly(SERVICE_DICT[agency], SWIFTLY_GTFS_RT_TRIP_UPDATES)
+        feed.ParseFromString(response_data)
+        
+        trip_update_array = []
+        stop_time_array = []
+        vehicle_position_update_array = []
+        for entity in feed.entity:
+            trip_update_array.append({
                 'trip_id': entity.trip_update.trip.trip_id,
-                'stop_id': stop_time_update.stop_id,
-                'arrival': stop_time_update.arrival.time,
-                'departure': stop_time_update.departure.time,
-                'schedule_relationship': stop_time_update.schedule_relationship
+                'route_id': entity.trip_update.trip.route_id,
+                'start_time': entity.trip_update.trip.start_time,
+                'start_date': entity.trip_update.trip.start_date,
+                'direction_id': entity.trip_update.trip.direction_id,
+                'schedule_relationship': entity.trip_update.trip.schedule_relationship,
+                'agency_id': agency,
+                'timestamp': entity.trip_update.timestamp
             })
+            for stop_time_update in entity.trip_update.stop_time_update:
+                stop_time_array.append({
+                    'trip_id': entity.trip_update.trip.trip_id,
+                    'stop_id': stop_time_update.stop_id,
+                    'arrival': stop_time_update.arrival.time,
+                    'departure': stop_time_update.departure.time,
+                    'agency_id': agency,
+                    'schedule_relationship': stop_time_update.schedule_relationship
+                })
 
-    trip_update_df = pd.DataFrame(trip_update_array)
-    stop_time_df = pd.DataFrame(stop_time_array)
-    # print(trip_update_df)
-    # print(stop_time_df)
-    vehicle_positions_feed = FeedMessage()
-    response_data = connect_to_swiftly('bus', SWIFTLY_GTFS_RT_VEHICLE_POSITIONS)
-    vehicle_positions_feed.ParseFromString(response_data)
-    # print(vehicle_positions_feed)
-    for entity in vehicle_positions_feed.entity:
-        if entity.HasField('vehicle'):
-            vehicle_position_update_array.append({
-                'current_stop_sequence': entity.vehicle.current_stop_sequence,
-                'current_status': entity.vehicle.current_status,
-                'timestamp': entity.vehicle.timestamp,
-                'stop_id': entity.vehicle.stop_id,
-                'trip_id': entity.vehicle.trip.trip_id,
-                'trip_start_date': entity.vehicle.trip.start_date,
-                'trip_route_id': entity.vehicle.trip.route_id,
-                'position_latitude': entity.vehicle.position.latitude,
-                'position_longitude': entity.vehicle.position.longitude,
-                'position_bearing': entity.vehicle.position.bearing,
-                'position_speed': entity.vehicle.position.speed,
-                'vehicle_id': entity.vehicle.vehicle.id,
-                'vehicle_label': entity.vehicle.vehicle.label
-            })
-    vehicle_position_updates = pd.DataFrame(vehicle_position_update_array)
+        trip_update_df = pd.DataFrame(trip_update_array)
+        combined_trip_update_dataframes.append(trip_update_df)
+        stop_time_df = pd.DataFrame(stop_time_array)
+        combined_stop_time_dataframes.append(stop_time_df)
+        # print(trip_update_df)
+        # print(stop_time_df)
+        vehicle_positions_feed = FeedMessage()
+        response_data = connect_to_swiftly(SERVICE_DICT[agency], SWIFTLY_GTFS_RT_VEHICLE_POSITIONS)
+        vehicle_positions_feed.ParseFromString(response_data)
+        # print(vehicle_positions_feed)
+        for entity in vehicle_positions_feed.entity:
+            if entity.HasField('vehicle'):
+                vehicle_position_update_array.append({
+                    'current_stop_sequence': entity.vehicle.current_stop_sequence,
+                    'current_status': entity.vehicle.current_status,
+                    'timestamp': entity.vehicle.timestamp,
+                    'stop_id': entity.vehicle.stop_id,
+                    'trip_id': entity.vehicle.trip.trip_id,
+                    'trip_start_date': entity.vehicle.trip.start_date,
+                    'trip_route_id': entity.vehicle.trip.route_id,
+                    'position_latitude': entity.vehicle.position.latitude,
+                    'position_longitude': entity.vehicle.position.longitude,
+                    'position_bearing': entity.vehicle.position.bearing,
+                    'position_speed': entity.vehicle.position.speed,
+                    'vehicle_id': entity.vehicle.vehicle.id,
+                    'vehicle_label': entity.vehicle.vehicle.label,
+                    'agency_id': agency
+                })
+        vehicle_position_updates = pd.DataFrame(vehicle_position_update_array)
+        combined_vehicle_position_dataframes.append(vehicle_position_updates)
     # logging('vehicle_position_updates Data Frame: ' + str(vehicle_position_updates))
-    vehicle_position_updates.to_sql('vehicle_position_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
-    stop_time_df.to_sql('stop_time_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
-    trip_update_df.to_sql('trip_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
+    combined_trip_update_df = pd.concat(combined_trip_update_dataframes)
+    combined_stop_time_df = pd.concat(combined_stop_time_dataframes)
+    combined_vehicle_position_df = pd.concat(combined_vehicle_position_dataframes)
+    combined_vehicle_position_df.to_sql('vehicle_position_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
+    combined_stop_time_df.to_sql('stop_time_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
+    combined_trip_update_df.to_sql('trip_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
     process_end = timeit.default_timer()
     # print('===GTFS Update process took {} seconds'.format(process_end - process_start)+"===")
     print('===GTFS Update process took {} seconds'.format(process_end - process_start)+"===")

--- a/data-loading-service/app/utils/gtfs_static_helper.py
+++ b/data-loading-service/app/utils/gtfs_static_helper.py
@@ -1,3 +1,4 @@
+from calendar import calendar
 import pandas as pd
 import json
 from pathlib import Path
@@ -8,9 +9,15 @@ from .database_connector import *
 # from .utils.log_helper import *
 # engine = create_engine(Config.DB_URI, echo=False,executemany_mode="values")
 # Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-CALENDAR_DATES_URL = 'https://gitlab.com/LACMTA/gtfs_bus/-/raw/weekly-updated-service/calendar_dates.txt'
+CALENDAR_DATES_URL_BUS = 'https://gitlab.com/LACMTA/gtfs_bus/-/raw/weekly-updated-service/calendar_dates.txt'
+# CALENDAR_DATES_URL_RAIL = 'https://gitlab.com/LACMTA/gtfs_rail/-/raw/weekly-updated-service/calendar_dates.txt'
+CALENDAR_DATES_URL_RAIL = 'https://gitlab.com/LACMTA/gtfs_rail/-/raw/master/calendar_dates.txt'
 # session = Session()
 
 def update_calendar_dates():
-    calendar_dates_df = pd.read_csv(CALENDAR_DATES_URL)
+    calendar_dates_df_bus = pd.read_csv(CALENDAR_DATES_URL_BUS)
+    calendar_dates_df_bus['agency_id'] = 'LACMTA'
+    calendar_dates_df_rail = pd.read_csv(CALENDAR_DATES_URL_RAIL)
+    calendar_dates_df_rail['agency_id'] = 'LACMTA_Rail'
+    calendar_dates_df = pd.concat([calendar_dates_df_bus, calendar_dates_df_rail])
     calendar_dates_df.to_sql('calendar_dates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)

--- a/fastapi/app/config.py
+++ b/fastapi/app/config.py
@@ -24,7 +24,7 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.1.2"
+    CURRENT_VERSION = "2.1.3"
     API_LAST_UPDATE_TIME = os.path.getmtime(r'app/main.py')
     LOGZIO_TOKEN = os.environ.get('LOGZIO_TOKEN')
     LOGZIO_URL = os.environ.get('LOGZIO_URL')

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -36,10 +36,16 @@ def get_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
     return the_query
 
 def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
-    if trip_id is None:
-        the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
+    if trip_id is None or trip_id == '':
+        print('trip_id is none')
+        the_query = db.query(gtfs_models.TripUpdate.trip_id).filter(gtfs_models.TripUpdate.agency_id == agency_id).distinct().all()
     else:
+        print('trip_id is' + trip_id)
         the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
+    return the_query
+
+def get_gtfs_rt_trip_updates_all(db, agency_id:str):
+    the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
     return the_query
 
 def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str,agency_id: str):

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -37,15 +37,17 @@ def get_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
 
 def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
     if trip_id is None or trip_id == '':
-        print('trip_id is none')
         the_query = db.query(gtfs_models.TripUpdate.trip_id).filter(gtfs_models.TripUpdate.agency_id == agency_id).distinct().all()
     else:
-        print('trip_id is' + trip_id)
-        the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
+        the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
+        for row in the_query:
+            print(row.stop_time_updates)
     return the_query
 
 def get_gtfs_rt_trip_updates_all(db, agency_id:str):
-    the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
+    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
+    for row in the_query:
+        print(row.stop_time_updates)
     return the_query
 
 def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str,agency_id: str):

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -23,42 +23,49 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 # stop_times utils
-def get_bus_stop_times_by_route_code(db, route_code: int):
-    the_query = db.query(models.StopTimes).filter(models.StopTimes.route_code == route_code).all()
+def get_stop_times_by_route_code(db, route_code: int,agency_id: str):
+    the_query = db.query(models.StopTimes).filter(models.StopTimes.route_code == route_code,models.StopTimes.agency_id == agency_id).all()
     # user_dict = models.User[username]
     # return schemas.UserInDB(**user_dict)
     return the_query
 
-def get_bus_stop_times_by_trip_id(db, trip_id: str):
-    the_query = db.query(models.StopTimes).filter(models.StopTimes.trip_id == trip_id).all()
+def get_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
+    the_query = db.query(models.StopTimes).filter(models.StopTimes.trip_id == trip_id,models.StopTimes.agency_id == agency_id).all()
     # user_dict = models.User[username]route_code
     # return schemas.UserInDB(**user_dict)
     return the_query
 
-def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str):
+def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
     if trip_id is None:
-        the_query = db.query(gtfs_models.StopTimeUpdate).all()
+        the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
     else:
-        the_query = db.query(gtfs_models.StopTimeUpdate).filter(gtfs_models.StopTimeUpdate.trip_id == trip_id).all()
-    return the_query
-    
-def get_gtfs_rt_vehicle_positions_by_vehicle_id(db, vehicle_id: str):
-    if vehicle_id is None:
-        the_query = db.query(gtfs_models.VehiclePosition).all()
-    else:
-        the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.vehicle_id == vehicle_id).all()
+        the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
     return the_query
 
-def get_bus_stops(db, stop_code: int):
-    the_query = db.query(models.Stops).filter(models.Stops.stop_code == stop_code).all()
+def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
+    if trip_id is None:
+        the_query = db.query(gtfs_models.StopTimeUpdate).filter(gtfs_models.StopTimeUpdate.agency_id == agency_id).all()
+    else:
+        the_query = db.query(gtfs_models.StopTimeUpdate).filter(gtfs_models.StopTimeUpdate.trip_id == trip_id,gtfs_models.StopTimeUpdate.agency_id == agency_id).all()
+    return the_query
+    
+def get_gtfs_rt_vehicle_positions_by_vehicle_id(db, vehicle_id: str,agency_id: str):
+    if vehicle_id is None:
+        the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.agency_id == agency_id).all()
+    else:
+        the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.vehicle_id == vehicle_id,gtfs_models.VehiclePosition.agency_id == agency_id).all()
+    return the_query
+
+def get_bus_stops(db, stop_code: int,agency_id: str):
+    the_query = db.query(models.Stops).filter(models.Stops.stop_code == stop_code,models.Stops.agency_id == agency_id).all()
     # user_dict = models.User[username]
     # return schemas.UserInDB(**user_dict)
     return the_query
 
 # generic function to get the gtfs data
-def get_gtfs_data(db, tablename,column_name,query):
+def get_gtfs_data(db, tablename,column_name,query,agency_id):
     aliased_table = aliased(tablename)
-    the_query = db.query(aliased_table).filter(getattr(aliased_table,column_name) == query).all()
+    the_query = db.query(aliased_table).filter(getattr(aliased_table,column_name) == query,getattr(aliased_table,'agency_id') == agency_id).all()
     return the_query
     
 def get_bus_stops_by_name(db, name: str):

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -35,19 +35,19 @@ def get_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
     # return schemas.UserInDB(**user_dict)
     return the_query
 
+def temp_solution():
+    return True
+
 def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
-    if trip_id is None or trip_id == '':
-        the_query = db.query(gtfs_models.TripUpdate.trip_id).filter(gtfs_models.TripUpdate.agency_id == agency_id).distinct().all()
-    else:
-        the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
-        for row in the_query:
-            print(row.stop_time_updates)
+    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
+    for row in the_query:
+        temp_solution()
     return the_query
 
 def get_gtfs_rt_trip_updates_all(db, agency_id:str):
     the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
     for row in the_query:
-        print(row.stop_time_updates)
+        temp_solution()
     return the_query
 
 def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str,agency_id: str):

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -38,14 +38,50 @@ def get_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
 def temp_solution(val):
     return True
 
-def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
-    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
+def list_gtfs_rt_trips_by_field_name(db, field_name: str,agency_id: str):
+    the_query = db.query(getattr(gtfs_models.TripUpdate,field_name),gtfs_models.TripUpdate.agency_id).with_entities(getattr(gtfs_models.TripUpdate,field_name)).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
+    result = []
+    for row in the_query:
+        result.append(row[0])
+    return result
+
+def list_gtfs_rt_vehicle_positions_by_field_name(db, field_name: str,agency_id: str):
+    the_query = db.query(getattr(gtfs_models.VehiclePosition,field_name),gtfs_models.VehiclePosition.agency_id).with_entities(getattr(gtfs_models.VehiclePosition,field_name)).filter(gtfs_models.VehiclePosition.agency_id == agency_id).all()
+    result = []
+    for row in the_query:
+        result.append(row[0])
+    return result
+
+def get_gtfs_rt_trips_by_field_name(db, field_name: str,field_value: str,agency_id: str):
+    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(getattr(gtfs_models.TripUpdate,field_name) == field_value,gtfs_models.TripUpdate.agency_id == agency_id).all()
+    if len(the_query) == 0:
+        the_query = '{message:' + field_value + ' not found in ' + field_name + ' }'
+        return the_query
+    for row in the_query:
+        temp_solution(row.stop_time_updates)
+    return the_query
+    
+def get_all_gtfs_rt_trips(db, agency_id:str):
+    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
     for row in the_query:
         temp_solution(row.stop_time_updates)
     return the_query
 
-def get_gtfs_rt_trip_updates_all(db, agency_id:str):
-    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
+def get_all_gtfs_rt_vehicle_positions(db, agency_id: str):
+    the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.agency_id == agency_id).all()
+    return the_query
+
+def get_gtfs_rt_vehicle_positions_by_field_name(db, field_name: str,field_value: str,agency_id: str):
+    if field_value is None:
+        the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.agency_id == agency_id).all()
+    the_query = db.query(gtfs_models.VehiclePosition).filter(getattr(gtfs_models.VehiclePosition,field_name) == field_value,gtfs_models.VehiclePosition.agency_id == agency_id).all()
+    if len(the_query) == 0:
+        the_query = '{message:' + field_value + ' not found in ' + field_name + ' }'
+        return the_query
+    return the_query
+
+def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
+    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
     for row in the_query:
         temp_solution(row.stop_time_updates)
     return the_query
@@ -57,12 +93,6 @@ def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
         the_query = db.query(gtfs_models.StopTimeUpdate).filter(gtfs_models.StopTimeUpdate.trip_id == trip_id,gtfs_models.StopTimeUpdate.agency_id == agency_id).all()
     return the_query
     
-def get_gtfs_rt_vehicle_positions_by_vehicle_id(db, vehicle_id: str,agency_id: str):
-    if vehicle_id is None:
-        the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.agency_id == agency_id).all()
-    else:
-        the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.vehicle_id == vehicle_id,gtfs_models.VehiclePosition.agency_id == agency_id).all()
-    return the_query
 
 def get_bus_stops(db, stop_code: int,agency_id: str):
     the_query = db.query(models.Stops).filter(models.Stops.stop_code == stop_code,models.Stops.agency_id == agency_id).all()
@@ -70,8 +100,8 @@ def get_bus_stops(db, stop_code: int,agency_id: str):
     # return schemas.UserInDB(**user_dict)
     return the_query
 
-# generic function to get the gtfs data
-def get_gtfs_data(db, tablename,column_name,query,agency_id):
+# generic function to get the gtfs static data
+def get_gtfs_static_data(db, tablename,column_name,query,agency_id):
     aliased_table = aliased(tablename)
     the_query = db.query(aliased_table).filter(getattr(aliased_table,column_name) == query,getattr(aliased_table,'agency_id') == agency_id).all()
     return the_query

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -35,19 +35,19 @@ def get_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
     # return schemas.UserInDB(**user_dict)
     return the_query
 
-def temp_solution():
+def temp_solution(val):
     return True
 
 def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
     the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
     for row in the_query:
-        temp_solution()
+        temp_solution(row.stop_time_updates)
     return the_query
 
 def get_gtfs_rt_trip_updates_all(db, agency_id:str):
     the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
     for row in the_query:
-        temp_solution()
+        temp_solution(row.stop_time_updates)
     return the_query
 
 def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str,agency_id: str):

--- a/fastapi/app/frontend/index.html
+++ b/fastapi/app/frontend/index.html
@@ -53,6 +53,15 @@
                 </ul>
               </li>
               </ul>
+            
+            <h2>Conventions</h2>
+            
+            <ul>
+              <li>All GTFS endpoints require an agency_id.</li>
+              <li>If no specific value for a parameter is specified at the end, the endpoint will return all values for that parameter.</li>
+            </ul>
+
+            
 
           </main>
         </div>

--- a/fastapi/app/frontend/login.html
+++ b/fastapi/app/frontend/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Metro API 2.1.2</title>
+    <title>Metro API 2.1.3</title>
     <link rel="stylesheet" href="https://lacmta.github.io/design-system/dist/css/styles.css" type="text/css">
     <script src="https://lacmta.github.io/design-system/dist/js/uswds.min.js"></script>
     <script src="https://lacmta.github.io/design-system/dist/js/uswds-init.min.js"></script>

--- a/fastapi/app/gtfs_models.py
+++ b/fastapi/app/gtfs_models.py
@@ -14,11 +14,10 @@ GTFSrtBase = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
 
 class TripUpdate(GTFSrtBase):
     __tablename__ = 'trip_updates'
-    oid = Column(Integer, primary_key=True)
 
     # This replaces the TripDescriptor message
     # TODO: figure out the relations
-    trip_id = Column(String(64))
+    trip_id = Column(String(64), primary_key=True)
     route_id = Column(String(64))
     start_time = Column(String(8))
     start_date = Column(String(10))

--- a/fastapi/app/gtfs_models.py
+++ b/fastapi/app/gtfs_models.py
@@ -26,7 +26,8 @@ class TripUpdate(GTFSrtBase):
     # TODO: add a domain
     schedule_relationship = Column(String(9))
     direction_id = Column(Integer)
-    
+
+    agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
     # StopTimeUpdates = relationship('StopTimeUpdate', backref='TripUpdate')
@@ -48,7 +49,8 @@ class StopTimeUpdate(GTFSrtBase):
     # TODO: Fill one from the other
     stop_sequence = Column(Integer)
     stop_id = Column(String(10),primary_key=True)
-
+    trip_id = Column(String(64))
+    agency_id = Column(String)
     # TODO: Add domain
     schedule_relationship = Column(String(9))
     # Link it to the TripUpdate
@@ -78,6 +80,7 @@ class VehiclePosition(GTFSrtBase):
     vehicle_id = Column(String,primary_key=True)
     vehicle_label = Column(String)
 
+    agency_id = Column(String)
     timestamp = Column(Integer)
 
 

--- a/fastapi/app/gtfs_models.py
+++ b/fastapi/app/gtfs_models.py
@@ -14,10 +14,9 @@ GTFSrtBase = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
 
 class TripUpdate(GTFSrtBase):
     __tablename__ = 'trip_updates'
-
     # This replaces the TripDescriptor message
     # TODO: figure out the relations
-    trip_id = Column(String(64), primary_key=True)
+    trip_id = Column(String(64),primary_key=True)
     route_id = Column(String(64))
     start_time = Column(String(8))
     start_date = Column(String(10))
@@ -29,7 +28,7 @@ class TripUpdate(GTFSrtBase):
     agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
-    # StopTimeUpdates = relationship('StopTimeUpdate', backref='TripUpdate')
+    stop_time_updates = relationship('StopTimeUpdate', backref=backref('trip_updates',lazy="joined"))
     class Config:
         schema_extra = {
             "definition": {
@@ -46,14 +45,14 @@ class StopTimeUpdate(GTFSrtBase):
     # oid = Column(Integer, )
 
     # TODO: Fill one from the other
-    stop_sequence = Column(Integer)
+    # stop_sequence = Column(Integer)
     stop_id = Column(String(10),primary_key=True)
-    trip_id = Column(String(64))
+    trip_id = Column(String, ForeignKey('trip_updates.trip_id'))
     agency_id = Column(String)
     # TODO: Add domain
     schedule_relationship = Column(String(9))
     # Link it to the TripUpdate
-    # trip_update_id = Column(Integer, ForeignKey('trip_updates.oid'))
+    # trip_id = Column(Integer,)
 
 class VehiclePosition(GTFSrtBase):
     __tablename__ = "vehicle_position_updates"

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -213,7 +213,17 @@ async def get_time():
     return {current_time}
 
 
-@app.get("/{agency_id}/trip_updates/{trip_id}")
+@app.get("/{agency_id}/trip_updates/")
+async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,db: Session = Depends(get_db)):
+    result = crud.get_gtfs_rt_trip_updates_all(db,agency_id)
+    return result
+
+@app.get("/{agency_id}/trip_updates/trip_id/")
+async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,db: Session = Depends(get_db)):
+    result = crud.get_gtfs_rt_trips_by_trip_id(db,'',agency_id)
+    return result
+
+@app.get("/{agency_id}/trip_updates/trip_id/{trip_id}")
 async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,trip_id=Optional[str],db: Session = Depends(get_db)):
     result = crud.get_gtfs_rt_trips_by_trip_id(db,trip_id,agency_id)
     return result
@@ -230,13 +240,6 @@ async def get_gtfs_rt_stop_times_updates_by_trip_id(agency_id,trip_id, db: Sessi
     # json_compatible_item_data = jsonable_encoder(result)
     # return JSONResponse(content=json_compatible_item_data)
     return result
-
-@app.get("/{agency_id}/trip_updates/{trip_id}")
-async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,trip_id, db: Session = Depends(get_db)):
-    result = crud.get_gtfs_rt_trips_by_trip_id(db,trip_id,agency_id)
-    return result
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
 
 ### bus static endpoints ### :)
 

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -41,7 +41,7 @@ from .database import Session, engine, session, get_db
 from .config import Config
 from pathlib import Path
 
-from logzio.handler import LogzioHandler
+# from logzio.handler import LogzioHandler
 
 UPDATE_INTERVAL = 300
 
@@ -56,10 +56,16 @@ PATH_TO_CALENDAR_JSON = os.path.realpath(TARGET_PATH_CALENDAR_JSON)
 PATH_TO_CANCELED_JSON = os.path.realpath(TARGET_PATH_CANCELED_JSON)
 
 
+tags_metadata = [
+    {"name": "Real-Time data", "description": "Includes GTFS-RT data for Metro Rail and Metro Bus."},
+    {"name": "Static data", "description": "GTFS Static data, including routes, stops, and schedules."},
+    {"name": "Other data", "description": "Other data on an as-needed basis."},
+    {"name": "User Methods", "description": "Methods for user authentication and authorization."},
+]
 
 models.Base.metadata.create_all(bind=engine)
 
-app = FastAPI(docs_url="/")
+app = FastAPI(openapi_tags=tags_metadata,docs_url="/")
 # db = connect(host='', port=0, timeout=None, source_address=None)
 
 templates = Jinja2Templates(directory="app/frontend")
@@ -101,75 +107,65 @@ app = FastAPI()
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
+#### Helper functions ####
+
+def get_columns_from_schema(schema):
+    if schema == 'trip_updates':
+        return schemas.TripUpdates.__fields__.keys()
+    if schema == 'vehicle_position_updates':
+        return schemas.VehiclePositions.__fields__.keys()
+
+def standardize_string(input_string):
+    return input_string.lower().replace(" ", "")
 ####################
 #  Begin Routes
 ####################
 
-# tokens
+@app.get("/{agency_id}/trip_updates/{field_name}/{field_value}",tags=["Real-Time data"])
+async def get_gtfs_rt_trip_updates_by_field_name(agency_id,field_name,field_value=Optional[str],db: Session = Depends(get_db)):
+# async def get_gtfs_rt_trip_updates_by_field_name(agency_id,field_name,field_value=Optional[str],db: Session = Depends(get_db)):
+    if field_name == 'all':
+        result = crud.get_all_gtfs_rt_trips(db,'',agency_id)
+        return result
+    if field_name in get_columns_from_schema('trip_updates'):
+        if field_value == 'list':
+            result = crud.list_gtfs_rt_trips_by_field_name(db,field_name,agency_id)
+            return result
+        multiple_values = field_value.split(',')
+        if len(multiple_values) > 1:
+            result_array = []
+            for value in multiple_values:
+                result = crud.get_gtfs_rt_trips_by_field_name(db,field_name,value,agency_id)
+                result_array.append(result)
+            return result_array
+        result = crud.get_gtfs_rt_trips_by_field_name(db,field_name,field_value,agency_id)
+        return result
 
-@app.get("/verify_email/{email_verification_token}")
-async def verify_email_route(email_verification_token: str,db: Session = Depends(get_db)):
-    
-    if not crud.verify_email(email_verification_token,db):
-        return False
+@app.get("/{agency_id}/vehicle_positions/{field_name}/{field_value}",tags=["Real-Time data"])
+async def vehicle_position_updates(agency_id,field_name,field_value=Optional[str],db: Session = Depends(get_db)):
+    # result = crud.get_gtfs_rt_vehicle_positions_by_field_name(db,field_name,field_value,agency_id)
+    if field_name == 'all':
+        result = crud.get_all_gtfs_rt_vehicle_positions(db,agency_id)
+        return result
+    if field_name in get_columns_from_schema('vehicle_position_updates'):
+        if field_value == 'list':
+            result = crud.list_gtfs_rt_vehicle_positions_by_field_name(db,field_name,agency_id)
+            return result
+        multiple_values = field_value.split(',')
+        if len(multiple_values) > 1:
+            result_array = []
+            for value in multiple_values:
+                result = crud.get_gtfs_rt_vehicle_positions_by_field_name(db,field_name,value,agency_id)
+                if len(result) == 0:
+                    result = '{message:' + value + ' not found in ' + field_name + ' }'
+                result_array.append(result)
+            return result_array
+        result = crud.get_gtfs_rt_vehicle_positions_by_field_name(db,field_name,field_value,agency_id)
+        if len(result) == 0:
+            return '{message:' + field_value + ' not found in ' + field_name + ' }'
+        return result
 
-    return "email verified"
-
-@app.post("/token", response_model=schemas.Token)
-async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(),db: Session = Depends(get_db)):
-    user = crud.authenticate_user(form_data.username, form_data.password,db)
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    access_token_expires = timedelta(minutes=Config.ACCESS_TOKEN_EXPIRE_MINUTES)
-    access_token = crud.create_access_token(
-        data={"sub": user.username}, expires_delta=access_token_expires
-    )
-    return {"access_token": access_token, "token_type": "bearer"}
-
-
-
-
-# end tokens
-
-
-@app.post("/users/", response_model=schemas.User)
-def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
-    db_user = crud.get_user_by_email(db, email=user.email)
-    if db_user:
-        raise HTTPException(status_code=400, detail="Email already registered")
-    return crud.create_user(db=db, user=user)
-
-@app.get("/users/{username}", response_model=schemas.User)
-def read_user(username: str, db: Session = Depends(get_db),token: str = Depends(oauth2_scheme)):
-    db_user = crud.get_user(db, username=username)
-    if db_user is None:
-        raise HTTPException(status_code=404, detail="User not found")
-    return db_user
-
-# @app.get("/items/")
-# async def read_items(token: str = Depends(oauth2_scheme)):
-#     return {"token": token}
-
-@app.get("/get_gopass_schools")
-async def get_gopass_schools(db: Session = Depends(get_db),show_missing: bool = False):
-    result = crud.get_gopass_schools(db,show_missing)
-    json_compatible_item_data = jsonable_encoder(result)
-    return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/calendar_dates")
-async def get_calendar_dates_from_db(db: Session = Depends(get_db)):
-    result = crud.get_calendar_dates(db)
-    calendar_dates = jsonable_encoder(result)
-    return JSONResponse(content={"calendar_dates":calendar_dates})
-
-def standardize_string(input_string):
-    return input_string.lower().replace(" ", "")
-
-@app.get("/canceled_service_summary")
+@app.get("/canceled_service_summary",tags=["Real-Time data"])
 async def get_canceled_trip_summary(db: Session = Depends(get_db)):
     result = crud.get_canceled_trips(db,'all')
     canceled_trips_summary = {}
@@ -194,108 +190,88 @@ async def get_canceled_trip_summary(db: Session = Depends(get_db)):
                 "total_canceled_trips":total_canceled_trips,
                 "last_updated":update_time}
 
-@app.get("/canceled_service/line/{line}")
+@app.get("/{agency_id}/stop_times/{trip_id}",tags=["Real-Time data"])
+async def get_gtfs_rt_stop_times_updates_by_trip_id(agency_id,trip_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_rt_stop_times_by_trip_id(db,trip_id,agency_id)
+    return result
+
+@app.get("/{agency_id}/stop_times/{trip_id}",tags=["Real-Time data"])
+async def get_stop_times_by_trip_and_agency(agency_id,trip_id, db: Session = Depends(get_db)):
+    result = crud.get_stop_times_by_trip_id(db,trip_id,agency_id)
+    return result
+
+#### END GTFS-RT Routes ####
+
+
+@app.get("/canceled_service/line/{line}",tags=["Real-Time data"])
 async def get_canceled_trip(db: Session = Depends(get_db),line: str = None):
     result = crud.get_canceled_trips(db,line)
     json_compatible_item_data = jsonable_encoder(result)
     return JSONResponse(content=json_compatible_item_data)
 
-@app.get("/canceled_service/all")
+@app.get("/canceled_service/all",tags=["Real-Time data"])
 async def get_canceled_trip(db: Session = Depends(get_db)):
     result = crud.get_canceled_trips(db,'all')
     json_compatible_item_data = jsonable_encoder(result)
     return JSONResponse(content=json_compatible_item_data)
 
 
+
+### Begin Static data endpoints ### :)
+### GTFS Static data ###
+@app.get("/calendar_dates",tags=["Static data"])
+async def get_calendar_dates_from_db(db: Session = Depends(get_db)):
+    result = crud.get_calendar_dates(db)
+    calendar_dates = jsonable_encoder(result)
+    return JSONResponse(content={"calendar_dates":calendar_dates})
+
+@app.get("/{agency_id}/stop_times/route_code/{route_code}",tags=["Static data"])
+async def get_stop_times_by_route_code_and_agency(agency_id,route_code, db: Session = Depends(get_db)):
+    result = crud.get_stop_times_by_route_code(db,route_code,agency_id)
+    return result
+
+@app.get("/{agency_id}/stops/{stop_id}",tags=["Static data"])
+async def get_bus_stops(agency_id,stop_id, db: Session = Depends(get_db)):
+    result = crud.get_bus_stops(db,stop_id,agency_id)
+    return result
+
+@app.get("/{agency_id}/trips/{trip_id}",tags=["Static data"])
+async def get_bus_trips(agency_id,trip_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_static_data(db,models.Trips,'trip_id',trip_id,agency_id)
+    return result
+
+@app.get("/{agency_id}/shapes/{shape_id}",tags=["Static data"])
+async def get_bus_shapes(agency_id,shape_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_static_data(db,models.Shapes,'shape_id',shape_id,agency_id)
+    return result
+
+@app.get("/{agency_id}/routes/{route_id}",tags=["Static data"])
+async def get_bus_routes(agency_id,route_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_static_data(db,models.Routes,'route_id',route_id,agency_id)
+    return result
+
+#### END GTFS Static data endpoints ####
+#### END Static data endpoints ####
+
+
+#### Begin Other data endpoints ####
+
+@app.get("/get_gopass_schools",tags=["Other data"])
+async def get_gopass_schools(db: Session = Depends(get_db),show_missing: bool = False):
+    result = crud.get_gopass_schools(db,show_missing)
+    json_compatible_item_data = jsonable_encoder(result)
+    return JSONResponse(content=json_compatible_item_data)
+
 @app.get("/time")
 async def get_time():
     current_time = datetime.now()
     return {current_time}
 
-
-@app.get("/{agency_id}/trip_updates/")
-async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,db: Session = Depends(get_db)):
-    result = crud.get_gtfs_rt_trip_updates_all(db,agency_id)
-    return result
-
-@app.get("/{agency_id}/trip_updates/trip_id/")
-async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,db: Session = Depends(get_db)):
-    result = crud.get_gtfs_rt_trips_by_trip_id(db,'',agency_id)
-    return result
-
-@app.get("/{agency_id}/trip_updates/trip_id/{trip_id}")
-async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,trip_id=Optional[str],db: Session = Depends(get_db)):
-    result = crud.get_gtfs_rt_trips_by_trip_id(db,trip_id,agency_id)
-    return result
-
-
-@app.get("/{agency_id}/vehicle_positions/{vehicle_id}")
-async def vehicle_position_updates(agency_id,vehicle_id=Optional[str],db: Session = Depends(get_db)):
-    result = crud.get_gtfs_rt_vehicle_positions_by_vehicle_id(db,vehicle_id,agency_id)
-    return result
-
-@app.get("/{agency_id}/stop_times/{trip_id}")
-async def get_gtfs_rt_stop_times_updates_by_trip_id(agency_id,trip_id, db: Session = Depends(get_db)):
-    result = crud.get_gtfs_rt_stop_times_by_trip_id(db,trip_id,agency_id)
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
-    return result
-
-### bus static endpoints ### :)
-
-@app.get("/{agency_id}/stop_times/{trip_id}")
-async def get_stop_times_by_trip_and_agency(agency_id,trip_id, db: Session = Depends(get_db)):
-    result = crud.get_stop_times_by_trip_id(db,trip_id,agency_id)
-    return result
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/{agency_id}/stop_times/route_code/{route_code}")
-async def get_stop_times_by_route_code_and_agency(agency_id,route_code, db: Session = Depends(get_db)):
-    result = crud.get_stop_times_by_route_code(db,route_code,agency_id)
-    return result
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/{agency_id}/stops/{stop_id}")
-async def get_bus_stops(agency_id,stop_id, db: Session = Depends(get_db)):
-    result = crud.get_bus_stops(db,stop_id,agency_id)
-    return result
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/{agency_id}/trips/{trip_id}")
-async def get_bus_trips(agency_id,trip_id, db: Session = Depends(get_db)):
-    # table_alias = aliased(models.Trips)
-    result = crud.get_gtfs_data(db,models.Trips,'trip_id',trip_id,agency_id)
-    return result
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/{agency_id}/shapes/{shape_id}")
-async def get_bus_shapes(agency_id,shape_id, db: Session = Depends(get_db)):
-    result = crud.get_gtfs_data(db,models.Shapes,'shape_id',shape_id,agency_id)
-    return result
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/{agency_id}/routes/{route_id}")
-async def get_bus_routes(agency_id,route_id, db: Session = Depends(get_db)):
-    result = crud.get_gtfs_data(db,models.Routes,'route_id',route_id,agency_id)
-    return result
-    # json_compatible_item_data = jsonable_encoder(result)
-    # return JSONResponse(content=json_compatible_item_data)
-    
 # @app.get("/agencies/")
 # async def root():
-#     return {"Metro API Version": "2.0.3"}
+#     return {"Metro API Version": "2.1.5"}
 
 # Frontend Routing
-
-@app.get("/login",response_class=HTMLResponse)
-def login(request:Request):
-    return templates.TemplateResponse("login.html", context= {"request": request})
-
 
 @app.get("/",response_class=HTMLResponse)
 def index(request:Request):
@@ -314,33 +290,86 @@ class LogFilter(logging.Filter):
         record.env = Config.RUNNING_ENV
         return True
 
-@app.on_event("startup")
-async def startup_event():
-    print("Starting up...")
-    uvicorn_access_logger = logging.getLogger("uvicorn.access")
-    uvicorn_error_logger = logging.getLogger("uvicorn.error")
-    logger = logging.getLogger("uvicorn.app")
+
+# tokens
+
+@app.get("/login",response_class=HTMLResponse,tags=["User Methods"])
+def login(request:Request):
+    return templates.TemplateResponse("login.html", context= {"request": request})
+
+
+@app.get("/verify_email/{email_verification_token}", tags=["User Methods"])
+async def verify_email_route(email_verification_token: str,db: Session = Depends(get_db)):
     
-    logzio_formatter = logging.Formatter("%(message)s")
-    logzio_uvicorn_access_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'uvicorn.access', 5, Config.LOGZIO_URL)
-    logzio_uvicorn_access_handler.setLevel(logging.INFO)
-    logzio_uvicorn_access_handler.setFormatter(logzio_formatter)
+    if not crud.verify_email(email_verification_token,db):
+        return False
 
-    logzio_uvicorn_error_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'uvicorn.error', 5, Config.LOGZIO_URL)
-    logzio_uvicorn_error_handler.setLevel(logging.INFO)
-    logzio_uvicorn_error_handler.setFormatter(logzio_formatter)
+    return "email verified"
 
-    logzio_app_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'fastapi.app', 5, Config.LOGZIO_URL)
-    logzio_app_handler.setLevel(logging.INFO)
-    logzio_app_handler.setFormatter(logzio_formatter)
+@app.post("/token", response_model=schemas.Token,tags=["User Methods"])
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(),db: Session = Depends(get_db)):
+    user = crud.authenticate_user(form_data.username, form_data.password,db)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token_expires = timedelta(minutes=Config.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = crud.create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
 
-    uvicorn_access_logger.addHandler(logzio_uvicorn_access_handler)
-    uvicorn_error_logger.addHandler(logzio_uvicorn_error_handler)
-    logger.addHandler(logzio_app_handler)
 
-    uvicorn_access_logger.addFilter(LogFilter())
-    uvicorn_error_logger.addFilter(LogFilter())
-    logger.addFilter(LogFilter())
+
+
+# end tokens
+
+
+@app.post("/users/", response_model=schemas.User,tags=["User Methods"])
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = crud.get_user_by_email(db, email=user.email)
+    if db_user:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    return crud.create_user(db=db, user=user)
+
+@app.get("/users/{username}", response_model=schemas.User,tags=["User Methods"])
+def read_user(username: str, db: Session = Depends(get_db),token: str = Depends(oauth2_scheme)):
+    db_user = crud.get_user(db, username=username)
+    if db_user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return db_user
+
+
+
+# @app.on_event("startup")
+# async def startup_event():
+#     print("Starting up...")
+#     uvicorn_access_logger = logging.getLogger("uvicorn.access")
+#     uvicorn_error_logger = logging.getLogger("uvicorn.error")
+#     logger = logging.getLogger("uvicorn.app")
+    
+#     logzio_formatter = logging.Formatter("%(message)s")
+#     logzio_uvicorn_access_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'uvicorn.access', 5, Config.LOGZIO_URL)
+#     logzio_uvicorn_access_handler.setLevel(logging.INFO)
+#     logzio_uvicorn_access_handler.setFormatter(logzio_formatter)
+
+#     logzio_uvicorn_error_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'uvicorn.error', 5, Config.LOGZIO_URL)
+#     logzio_uvicorn_error_handler.setLevel(logging.INFO)
+#     logzio_uvicorn_error_handler.setFormatter(logzio_formatter)
+
+#     logzio_app_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'fastapi.app', 5, Config.LOGZIO_URL)
+#     logzio_app_handler.setLevel(logging.INFO)
+#     logzio_app_handler.setFormatter(logzio_formatter)
+
+#     uvicorn_access_logger.addHandler(logzio_uvicorn_access_handler)
+#     uvicorn_error_logger.addHandler(logzio_uvicorn_error_handler)
+#     logger.addHandler(logzio_app_handler)
+
+#     uvicorn_access_logger.addFilter(LogFilter())
+#     uvicorn_error_logger.addFilter(LogFilter())
+#     logger.addFilter(LogFilter())
 
 app.add_middleware(
     CORSMiddleware,

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -175,7 +175,6 @@ async def get_canceled_trip_summary(db: Session = Depends(get_db)):
     canceled_trips_summary = {}
     total_canceled_trips = 0
     canceled_trip_json = jsonable_encoder(result)
-    print('result' + str(canceled_trip_json))
     if canceled_trip_json is None:
         return {"canceled_trips_summary": "",
                 "total_canceled_trips": 0,
@@ -215,83 +214,74 @@ async def get_time():
 
 
 @app.get("/{agency_id}/trip_updates/{trip_id}")
-async def trip_updates(agency_id,trip_id=Optional[str],db: Session = Depends(get_db)):
-    if agency_id == "LACMTA":
-        result = crud.get_bus_stop_times_by_trip_id(db,trip_id)
-        return result
-    elif agency_id == "LACMTA_Rail":
-        pass
-    else:
-        return {"error":"agency_id"}
+async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,trip_id=Optional[str],db: Session = Depends(get_db)):
+    result = crud.get_gtfs_rt_trips_by_trip_id(db,trip_id,agency_id)
+    return result
+
 
 @app.get("/{agency_id}/vehicle_positions/{vehicle_id}")
 async def vehicle_position_updates(agency_id,vehicle_id=Optional[str],db: Session = Depends(get_db)):
-    if agency_id == "LACMTA":
-        result = crud.get_gtfs_rt_vehicle_positions_by_vehicle_id(db,vehicle_id)
-        return result
+    result = crud.get_gtfs_rt_vehicle_positions_by_vehicle_id(db,vehicle_id,agency_id)
+    return result
 
-    elif agency_id == "LACMTA_Rail":
-        pass
-    else:
-        return {"error":"agency_id"}
+@app.get("/{agency_id}/stop_times/{trip_id}")
+async def get_gtfs_rt_stop_times_updates_by_trip_id(agency_id,trip_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_rt_stop_times_by_trip_id(db,trip_id,agency_id)
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
+    return result
 
+@app.get("/{agency_id}/trip_updates/{trip_id}")
+async def get_gtfs_rt_trip_updates_by_trip_id(agency_id,trip_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_rt_trips_by_trip_id(db,trip_id,agency_id)
+    return result
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
 
+### bus static endpoints ### :)
 
+@app.get("/{agency_id}/stop_times/{trip_id}")
+async def get_stop_times_by_trip_and_agency(agency_id,trip_id, db: Session = Depends(get_db)):
+    result = crud.get_stop_times_by_trip_id(db,trip_id,agency_id)
+    return result
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
 
-@app.get("/vehicle_positions/{service}")
-async def vehicle_positions(service, output_format: Optional[str] = None):
-    # format options:
-    # - json
-    result = None
-    valid_formats = ["json"]
-    if output_format:
-        if output_format in valid_formats:
-            result = get_vehicle_positions(service, output_format)
-            return result
-        else:
-            raise HTTPException(status_code=400, detail="Invalid format")
-    else:
-        result = get_vehicle_positions(service, '')
-        return Response(content=result, media_type="application/x-protobuf")
+@app.get("/{agency_id}/stop_times/route_code/{route_code}")
+async def get_stop_times_by_route_code_and_agency(agency_id,route_code, db: Session = Depends(get_db)):
+    result = crud.get_stop_times_by_route_code(db,route_code,agency_id)
+    return result
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
 
-### bus endpoints ### :)
+@app.get("/{agency_id}/stops/{stop_id}")
+async def get_bus_stops(agency_id,stop_id, db: Session = Depends(get_db)):
+    result = crud.get_bus_stops(db,stop_id,agency_id)
+    return result
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
 
-@app.get("/bus/stop_times/{trip_id}")
-async def get_bus_stop_times_by_route_code(trip_id, db: Session = Depends(get_db)):
-    result = crud.get_bus_stop_times_by_trip_id(db,trip_id)
-    json_compatible_item_data = jsonable_encoder(result)
-    return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/bus/stop_times/route_code/{route_code}")
-async def get_bus_stop_times_by_route_code(route_code, db: Session = Depends(get_db)):
-    result = crud.get_bus_stop_times_by_route_code(db,route_code)
-    json_compatible_item_data = jsonable_encoder(result)
-    return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/bus/stops/{stop_id}")
-async def get_bus_stops(stop_id, db: Session = Depends(get_db)):
-    result = crud.get_bus_stops(db,stop_id)
-    json_compatible_item_data = jsonable_encoder(result)
-    return JSONResponse(content=json_compatible_item_data)
-
-@app.get("/bus/trips/{trip_id}")
-async def get_bus_trips(trip_id, db: Session = Depends(get_db)):
+@app.get("/{agency_id}/trips/{trip_id}")
+async def get_bus_trips(agency_id,trip_id, db: Session = Depends(get_db)):
     # table_alias = aliased(models.Trips)
-    result = crud.get_gtfs_data(db,models.Trips,'trip_id',trip_id)
-    json_compatible_item_data = jsonable_encoder(result)
-    return JSONResponse(content=json_compatible_item_data)
+    result = crud.get_gtfs_data(db,models.Trips,'trip_id',trip_id,agency_id)
+    return result
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
 
-@app.get("/bus/shapes/{shape_id}")
-async def get_bus_shapes(shape_id, db: Session = Depends(get_db)):
-    result = crud.get_gtfs_data(db,models.Shapes,'shape_id',shape_id)
-    json_compatible_item_data = jsonable_encoder(result)
-    return JSONResponse(content=json_compatible_item_data)
+@app.get("/{agency_id}/shapes/{shape_id}")
+async def get_bus_shapes(agency_id,shape_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_data(db,models.Shapes,'shape_id',shape_id,agency_id)
+    return result
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
 
-@app.get("/bus/routes/{route_id}")
-async def get_bus_routes(route_id, db: Session = Depends(get_db)):
-    result = crud.get_gtfs_data(db,models.Routes,'route_id',route_id)
-    json_compatible_item_data = jsonable_encoder(result)
-    return JSONResponse(content=json_compatible_item_data)
+@app.get("/{agency_id}/routes/{route_id}")
+async def get_bus_routes(agency_id,route_id, db: Session = Depends(get_db)):
+    result = crud.get_gtfs_data(db,models.Routes,'route_id',route_id,agency_id)
+    return result
+    # json_compatible_item_data = jsonable_encoder(result)
+    # return JSONResponse(content=json_compatible_item_data)
     
 # @app.get("/agencies/")
 # async def root():

--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -27,6 +27,7 @@ class StopTimes(Base):
     destination_code = Column(String)
     timepoint = Column(Integer)
     bay_num = Column(Integer)
+    agency_id = Column(String)
     id = Column(Integer, primary_key=True, index=True)
 
 class Stops(Base):
@@ -41,6 +42,7 @@ class Stops(Base):
     location_type = Column(String)
     parent_station = Column(String)
     tpis_name = Column(String)
+    agency_id = Column(String)
 
 class Trips(Base):
     __tablename__ = "trips"
@@ -52,6 +54,7 @@ class Trips(Base):
     block_id = Column(Integer)
     shape_id = Column(String)
     trip_id_event = Column(String)
+    agency_id = Column(String)
 class Routes(Base):
     __tablename__ = "routes"
     route_id = Column(Integer, primary_key=True, index=True)
@@ -62,18 +65,22 @@ class Routes(Base):
     route_color = Column(String)
     route_text_color = Column(String)
     route_url = Column(String)
+    agency_id = Column(String)
 class Shapes(Base):
     __tablename__ = "shapes"
     shape_id = Column(String, primary_key=True, index=True)
     shape_pt_lat = Column(Float)
     shape_pt_lon = Column(Float)
     shape_pt_sequence = Column(Integer)
+    agency_id = Column(String)
 
 class CalendarDates(Base):
     __tablename__ = "calendar_dates"
     service_id = Column(String, primary_key=True, index=True)
+    agency_id = Column(String)
     date = Column(String)
     exception_type = Column(Integer)
+    agency_id = Column(String)
 #### end gtfs static models
 
 #### begin other models

--- a/fastapi/app/schemas.py
+++ b/fastapi/app/schemas.py
@@ -100,6 +100,18 @@ class Shapes(BaseModel):
     shape_pt_sequence: int
     agency_id: str
 
+class StopTimeUpdates(BaseModel):
+    stop_sequence: int
+    trip_id: str
+    stop_id: str
+    schedule_relationship: str
+    agency_id: str
+    class Config:
+        orm_mode = True
+    # oid: int
+    # trip_update_id: int
+
+
 class TripUpdates(BaseModel):
     trip_id: str
     route_id: str
@@ -109,17 +121,9 @@ class TripUpdates(BaseModel):
     direction_id: int
     timestamp: int
     agency_id: str
-    # StopTimeUpdates = Json
-
-class StopTimeUpdates(BaseModel):
-    stop_sequence: int
-    trip_id: str
-    stop_id: str
-    schedule_relationship: str
-    agency_id: str
-    # oid: int
-    # trip_update_id: int
-
+    stop_time_updates: StopTimeUpdates
+    class Config:
+        orm_mode = True
 class VehiclePositions(BaseModel):
     current_stop_sequence: int
     current_status: str

--- a/fastapi/app/schemas.py
+++ b/fastapi/app/schemas.py
@@ -42,6 +42,7 @@ class CanceledServiceData(BaseModel):
     trip_time_start: str
     trip_time_end: str
     trip_direction: str
+    agency_id: str
 
 class StopTimes(BaseModel):
     trip_id: str
@@ -58,6 +59,7 @@ class StopTimes(BaseModel):
     timepoint: int
     bay_num: int
     id: int
+    agency_id: str
 
 class Stops(BaseModel):
     stop_id: int
@@ -70,6 +72,7 @@ class Stops(BaseModel):
     location_type: str
     parent_station: str
     tpis_name: str
+    agency_id: str
 
 class Trips(BaseModel):
     route_id: int
@@ -80,6 +83,7 @@ class Trips(BaseModel):
     block_id: int
     shape_id: str
     trip_id_event: str
+    agency_id: str
 
 class Routes(BaseModel):
     route_id: int
@@ -87,12 +91,14 @@ class Routes(BaseModel):
     route_long_name: str
     route_desc: str
     route_type: int
+    agency_id: str
 
 class Shapes(BaseModel):
     shape_id: str
     shape_pt_lat: float
     shape_pt_lon: float
     shape_pt_sequence: int
+    agency_id: str
 
 class TripUpdates(BaseModel):
     trip_id: str
@@ -102,12 +108,15 @@ class TripUpdates(BaseModel):
     schedule_relationship: str
     direction_id: int
     timestamp: int
+    agency_id: str
     # StopTimeUpdates = Json
 
 class StopTimeUpdates(BaseModel):
     stop_sequence: int
+    trip_id: str
     stop_id: str
     schedule_relationship: str
+    agency_id: str
     # oid: int
     # trip_update_id: int
 
@@ -115,34 +124,35 @@ class VehiclePositions(BaseModel):
     current_stop_sequence: int
     current_status: str
     timestamp: int
-    stop_id = str
-    trip_id = str
-    trip_start_date = str
-    trip_route_id = str
+    stop_id: str
+    trip_id: str
+    trip_start_date: str
+    trip_route_id: str
 
-    position_latitude = float
-    position_longitude = float
-    position_bearing = float
-    position_speed = float
+    position_latitude: float
+    position_longitude: float
+    position_bearing: float
+    position_speed: float
 
-    vehicle_id = str
-    vehicle_label = str
-    id = int
-    timestamp = int
+    vehicle_id: str
+    vehicle_label: str
+    id: int
+    agency_id: str
+    timestamp: int
 
 class CalendarDates(BaseModel):
     service_id: str
     date: str
     exception_type: int
-
+    agency_id: str
 class GoPassSchools(BaseModel):
-    phone = str
-    participating = bool
-    school = str
-    district = str
-    address = str
-    notes = str
-    resolved = bool
+    phone: str
+    participating: bool
+    school: str
+    district: str
+    address: str
+    notes: str
+    resolved: bool
 
 class CanceledServices(BaseModel):
     dpce_date: str

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # Metro API v2
+
 Metro API v2 is an API for Metro's GTFS-RT data.
 
 ## Versioning
@@ -6,6 +7,7 @@ Metro API v2 is an API for Metro's GTFS-RT data.
 Metro API v2 uses a modified version of [Semantic Versioning](https://semver.org/), with major (`X`), minor(`x`), and hotfix(`*`) releases for the numbers respectively: `X.x.*`.
 
 More versioning information can be found in [versioning.md](versioning.md)
+
 ## Getting started
 
 ### Prerequistes
@@ -14,17 +16,23 @@ More versioning information can be found in [versioning.md](versioning.md)
 
 ### Local Deployment
 
-Below is the shell script that can run to get started with the repository locally.
+Install the repository locally. The application can be run directly or through a Docker container.
 
 ``` shell
 # clone the repository
 git clone https://github.com/LACMTA/metro_api_v2.git
 
-#change to the directory
-cd metro_api_v2
+# change to the directory
+cd metro-api-v2
 ```
 
-Run these commands in order to build the docker container and then run it.
+#### Environment Variables
+
+Create a `.env` file with the required variables.
+
+#### Running in Docker
+
+Build the docker container and then run it.
 
 ``` shell
 # creates image in current folder with tag nginx
@@ -34,29 +42,38 @@ docker build . -t metro-api-v2:metro-api-v2
 docker run --rm -it  -p 80:80/tcp metro-api-v2:metro-api-v2
 ```
 
-docker-compose stop -t 1
-
-Use this command to run locally.
+???
 
 ``` shell
+docker-compose stop -t 1
+```
+
+#### Running Locally
+
+``` shell
+# change to the API application directory
+cd fastapi
+
 # install the required libraries
 pip3 install -r requirements.txt
 
 # run uvicorn to serve the API
 uvicorn app.main:app --reload --port 1212
-
-
 ```
 
-Use this command to run uvicorn from Windows.  You may need to use Python 3.
+Use this command to run uvicorn from Windows.
 
-``` bash
+``` shell
 python -m uvicorn app.main:app --reload 
+
+# or
+
+python3 -m uvicorn app.main:app --reload
 ```
 
 ### Misc Commands
 
-```
+``` shell
 docker build -t metro-api-v2:metro-api-v2 .
 docker compose up
 
@@ -85,3 +102,8 @@ Go to `Run -> Open Configurations` and add this to the `launch.json` file:
 This will tell the debugger to launch uvicorn as a python module, which is the equivalent of running `python -m uvicorn` in the terminal.  The `justMyCode` setting tells the debugger to only debug your code and not the included libraries.
 
 To use this configuration, press `F1` or `ctrl-shift-P` and choose `Debug: Select and Start Debugging`.  From the list, select the `Python: Module` configuration.
+
+## General Endpoint Naming Conventions
+
+- All GTFS endpoints require an `agency_id`.
+- If no specific value for a parameter is specified at the end, the endpoint will return all values for that parameter.


### PR DESCRIPTION
### Change Log (updated: 10/18/22)

- feat: added metro rail endpoint to data
- feat: data-loading-service loops through for rail and bus
- feat: added `LACMTA` for bus and `LACMTA_Rail` for all data models
- refactor: fastapi return values to not return `json`
- feat: [api] use `General Endpoint Naming Conventions`
- feat: [api] functions to `crud.py`
- feat: `multiple comma-separated` support for intake of `gtfs-rt` values
- feat: removed unused routes
- refactor: organized routes into 4 categories: "Real-Time data","Static data", "Other data", "User Methods"

### Todo
- todo: need to add data that loads static gtfs shapes, etc. into it

### Note
Remember to change the `apps/config.py`'s `Config.TARGET_DB_SCHEMA` to `metro_api` for **production**!

Closes #70 
