### PR TITLE
Metro rail endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,7 @@
       "request": "launch",
       "module": "uvicorn",
       "args": ["app.main:app", "--reload"],
+      "cwd": "${workspaceFolder}\\fastapi",
       "justMyCode": true
     },
     {


### PR DESCRIPTION
Some changes from #69 that did not make it before the PR:

- fix: Separate all endpoints created for VehiclePositions and TripUpdates because it doesn't get handled by the {field_name}/{field_value} endpoints.
- refactor: Enums created for agency_id, VehiclePositions field_name, and TripUpdates field_name values so that they are selectable via a dropdown from the docs/ page.

Also updated the python debug config settings to account for the new folder structure.