### PR TITLE
JSON loading for stop-updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ sandbox/
 app/secrets.py
 **/secrets.py
 fastapi/app/secrets.py
+appdata/gtfs-static/**/

--- a/data-loading-service/app/models/gtfs_rt.py
+++ b/data-loading-service/app/models/gtfs_rt.py
@@ -3,6 +3,7 @@
 import enum
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Boolean, Float, MetaData,Enum
+from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.orm import relationship, backref
 from config import Config
 GTFSrtBase = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
@@ -16,6 +17,20 @@ class VehicleStopStatus(enum.Enum):
 # TripUpdate
 # StopTimeUpdate
 # VehiclePosition
+
+class StopTimeUpdate(GTFSrtBase):
+    __tablename__ = 'stop_time_updates'
+    # oid = Column(Integer, )
+
+    # TODO: Fill one from the other
+    # stop_sequence = Column(Integer)
+    stop_id = Column(String(10),primary_key=True)
+    agency_id = Column(String)
+    
+    # TODO: Add domain
+    schedule_relationship = Column(String(9))
+    # Link it to the TripUpdate
+    trip_id = Column(String, ForeignKey('trip_updates.trip_id'))
 
 class TripUpdate(GTFSrtBase):
     __tablename__ = 'trip_updates'
@@ -35,6 +50,7 @@ class TripUpdate(GTFSrtBase):
     agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
+    stop_time_json = Column(JSON)
     stop_time_updates = relationship('StopTimeUpdate', backref=backref('trip_updates',lazy="joined"))
     class Config:
         schema_extra = {
@@ -47,19 +63,6 @@ class TripUpdate(GTFSrtBase):
             }
         }
 
-class StopTimeUpdate(GTFSrtBase):
-    __tablename__ = 'stop_time_updates'
-    # oid = Column(Integer, )
-
-    # TODO: Fill one from the other
-    # stop_sequence = Column(Integer)
-    stop_id = Column(String(10),primary_key=True)
-    agency_id = Column(String)
-    
-    # TODO: Add domain
-    schedule_relationship = Column(String(9))
-    # Link it to the TripUpdate
-    trip_id = Column(String, ForeignKey('trip_updates.trip_id'))
 
 class VehiclePosition(GTFSrtBase):
     __tablename__ = "vehicle_position_updates"


### PR DESCRIPTION
### Change log
feat: [data-loading] added `json` object for `stop-updates`
feat: [data-loading] added model for json type

### Todo 
(In order to fully close #84)
1. Return the object for the `all` end point in the front-end.
2. Either this merge (#85) needs to be pushed to `dev` OR dev needs to be turned off before can work on **1.** because `trip_updates` does not have the new `json` column and its being deleted each time by the `dev` server's `data-loading` process. :(