### PR TITLE
Reformat gtfs rt endpoints 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ fastapi/app/secrets.py
 **/gtfs_rail.zip
 appdata/gtfs-static/gtfs_rail.zip
 appdata/gtfs-static/gtfs_bus.zip
+test.py

--- a/data-loading-service/app/config.py
+++ b/data-loading-service/app/config.py
@@ -27,7 +27,7 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.1.4"
+    CURRENT_VERSION = "2.1.5"
     # API_LAST_UPDATE_TIME = os.path.getmtime(r'main.py')
     LOGZIO_TOKEN = os.environ.get('LOGZIO_TOKEN')
     LOGZIO_URL = os.environ.get('LOGZIO_URL')

--- a/data-loading-service/app/models/gtfs_rt.py
+++ b/data-loading-service/app/models/gtfs_rt.py
@@ -23,7 +23,7 @@ class StopTimeUpdate(GTFSrtBase):
     # oid = Column(Integer, )
 
     # TODO: Fill one from the other
-    # stop_sequence = Column(Integer)
+    stop_sequence = Column(Integer)
     stop_id = Column(String(10),primary_key=True)
     agency_id = Column(String)
     

--- a/data-loading-service/app/models/gtfs_rt.py
+++ b/data-loading-service/app/models/gtfs_rt.py
@@ -3,7 +3,7 @@
 import enum
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Boolean, Float, MetaData,Enum
-from sqlalchemy.dialects.postgresql import JSON
+# from sqlalchemy.dialects.postgresql import ARRAY,JSON
 from sqlalchemy.orm import relationship, backref
 from config import Config
 GTFSrtBase = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
@@ -23,7 +23,7 @@ class StopTimeUpdate(GTFSrtBase):
     # oid = Column(Integer, )
 
     # TODO: Fill one from the other
-    stop_sequence = Column(Integer)
+    stop_sequence = Column(Integer,default='')
     stop_id = Column(String(10),primary_key=True)
     agency_id = Column(String)
     
@@ -50,7 +50,7 @@ class TripUpdate(GTFSrtBase):
     agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
-    stop_time_json = Column(JSON)
+    stop_time_json = Column(String)
     stop_time_updates = relationship('StopTimeUpdate', backref=backref('trip_updates',lazy="joined"))
     class Config:
         schema_extra = {

--- a/data-loading-service/app/utils/gtfs_rt_helper.py
+++ b/data-loading-service/app/utils/gtfs_rt_helper.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from soupsieve import match
 from sqlalchemy.orm import Session,sessionmaker
 from sqlalchemy import create_engine, inspect
-from sqlalchemy.dialects.postgresql import JSON
+# from sqlalchemy.dialects.postgresql import ARRAY,JSON
 from models.gtfs_rt import *
 from config import Config
 
@@ -108,8 +108,7 @@ def update_gtfs_realtime_data():
         stop_time_array = []
         vehicle_position_update_array = []
         for entity in feed.entity:
-            this_stop_time_json_array = []
-            this_stop_time_json = {}
+            this_stop_time_json_array = []            
             for stop_time_update in entity.trip_update.stop_time_update:
                 this_stop_time_json={
                     'trip_id': entity.trip_update.trip.trip_id,
@@ -122,13 +121,14 @@ def update_gtfs_realtime_data():
                 }
                 stop_time_array.append(this_stop_time_json)
                 this_stop_time_json_array.append(this_stop_time_json)
+            string_of_json = str(this_stop_time_json_array)
             trip_update_array.append({
                 'trip_id': entity.trip_update.trip.trip_id,
                 'route_id': entity.trip_update.trip.route_id,
                 'start_time': entity.trip_update.trip.start_time,
                 'start_date': entity.trip_update.trip.start_date,
                 'direction_id': entity.trip_update.trip.direction_id,
-                'stop_time_json': this_stop_time_json,
+                'stop_time_json': string_of_json,
                 'schedule_relationship': entity.trip_update.trip.schedule_relationship,
                 'agency_id': agency,
                 'timestamp': entity.trip_update.timestamp
@@ -168,7 +168,8 @@ def update_gtfs_realtime_data():
     combined_vehicle_position_df = pd.concat(combined_vehicle_position_dataframes)
     combined_vehicle_position_df.to_sql('vehicle_position_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
     combined_stop_time_df.to_sql('stop_time_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
-    combined_trip_update_df.to_sql('trip_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA,dtype={'stop_time_json': JSON})
+    combined_trip_update_df['stop_time_json'].astype(str)
+    combined_trip_update_df.to_sql('trip_updates',engine,index=False,if_exists="replace",schema=Config.TARGET_DB_SCHEMA)
     process_end = timeit.default_timer()
     # print('===GTFS Update process took {} seconds'.format(process_end - process_start)+"===")
     print('===GTFS Update process took {} seconds'.format(process_end - process_start)+"===")

--- a/data-loading-service/app/utils/gtfs_rt_helper.py
+++ b/data-loading-service/app/utils/gtfs_rt_helper.py
@@ -108,18 +108,20 @@ def update_gtfs_realtime_data():
         stop_time_array = []
         vehicle_position_update_array = []
         for entity in feed.entity:
+            this_stop_time_json_array = []
             this_stop_time_json = {}
-
             for stop_time_update in entity.trip_update.stop_time_update:
                 this_stop_time_json={
                     'trip_id': entity.trip_update.trip.trip_id,
                     'stop_id': stop_time_update.stop_id,
                     'arrival': stop_time_update.arrival.time,
                     'departure': stop_time_update.departure.time,
+                    'stop_sequence': stop_time_update.stop_sequence,
                     'agency_id': agency,
                     'schedule_relationship': stop_time_update.schedule_relationship
                 }
                 stop_time_array.append(this_stop_time_json)
+                this_stop_time_json_array.append(this_stop_time_json)
             trip_update_array.append({
                 'trip_id': entity.trip_update.trip.trip_id,
                 'route_id': entity.trip_update.trip.route_id,

--- a/fastapi/app/config.py
+++ b/fastapi/app/config.py
@@ -24,7 +24,7 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.1.4"
+    CURRENT_VERSION = "2.1.5"
     API_LAST_UPDATE_TIME = os.path.getmtime(r'app/main.py')
     LOGZIO_TOKEN = os.environ.get('LOGZIO_TOKEN')
     LOGZIO_URL = os.environ.get('LOGZIO_URL')

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -62,20 +62,25 @@ def get_gtfs_rt_trips_by_field_name(db, field_name: str,field_value: str,agency_
     if field_name == 'stop_id':
         the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(getattr(gtfs_models.StopTimeUpdate,field_name) == field_value,gtfs_models.TripUpdate.agency_id == agency_id).all()
     else:
-        the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(getattr(gtfs_models.TripUpdate,field_name) == field_value,gtfs_models.TripUpdate.agency_id == agency_id).all()
+        the_query = db.query(gtfs_models.TripUpdate).filter(getattr(gtfs_models.TripUpdate,field_name) == field_value,gtfs_models.TripUpdate.agency_id == agency_id).all()
         if len(the_query) == 0:
             the_query = db.query(gtfs_models.TripUpdate).filter(getattr(gtfs_models.TripUpdate,field_name) == field_value,gtfs_models.TripUpdate.agency_id == agency_id).all()
             return the_query
     if the_query:
         for row in the_query:
-            temp_solution(row.stop_time_updates)
+            row = vehicle_position_reformat(row)
+            result.append(row)
     return the_query
-    
+
+        
+        
 def get_all_gtfs_rt_trips(db, agency_id:str):
-    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
+    the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
+    result = []
     for row in the_query:
-        temp_solution(row.stop_time_updates)
-    return the_query
+        row = trip_update_reformat(row)
+        result.append(row)
+    return result
 
 def get_all_gtfs_rt_vehicle_positions(db, agency_id: str):
     the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.agency_id == agency_id).all()
@@ -83,7 +88,7 @@ def get_all_gtfs_rt_vehicle_positions(db, agency_id: str):
     for row in the_query:
         row = vehicle_position_reformat(row)
         result.append(row)
-    return the_query
+    return result
 
 def get_gtfs_rt_vehicle_positions_by_field_name(db, field_name: str,field_value: str,agency_id: str):
     if field_value is None:
@@ -96,10 +101,13 @@ def get_gtfs_rt_vehicle_positions_by_field_name(db, field_name: str,field_value:
     return result
 
 def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
-    the_query = db.query(gtfs_models.TripUpdate).join(gtfs_models.StopTimeUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
+    the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
+    result = []
     for row in the_query:
-        temp_solution(row.stop_time_updates)
-    return the_query
+        row = trip_update_reformat(row)
+        result.append(row)
+    return result
+
 
 def get_gtfs_rt_stop_times_by_trip_id(db, trip_id: str,agency_id: str):
     if trip_id is None:

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -67,10 +67,11 @@ def get_gtfs_rt_trips_by_field_name(db, field_name: str,field_value: str,agency_
             the_query = db.query(gtfs_models.TripUpdate).filter(getattr(gtfs_models.TripUpdate,field_name) == field_value,gtfs_models.TripUpdate.agency_id == agency_id).all()
             return the_query
     if the_query:
+        result = []
         for row in the_query:
-            row = vehicle_position_reformat(row)
-            result.append(row)
-    return the_query
+            new_row = trip_update_reformat(row)
+            result.append(new_row)
+    return result
 
         
         
@@ -78,16 +79,16 @@ def get_all_gtfs_rt_trips(db, agency_id:str):
     the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()
     result = []
     for row in the_query:
-        row = trip_update_reformat(row)
-        result.append(row)
+        new_row = trip_update_reformat(row)
+        result.append(new_row)
     return result
 
 def get_all_gtfs_rt_vehicle_positions(db, agency_id: str):
     the_query = db.query(gtfs_models.VehiclePosition).filter(gtfs_models.VehiclePosition.agency_id == agency_id).all()
     result = []
     for row in the_query:
-        row = vehicle_position_reformat(row)
-        result.append(row)
+        new_row = vehicle_position_reformat(row)
+        result.append(new_row)
     return result
 
 def get_gtfs_rt_vehicle_positions_by_field_name(db, field_name: str,field_value: str,agency_id: str):
@@ -96,16 +97,16 @@ def get_gtfs_rt_vehicle_positions_by_field_name(db, field_name: str,field_value:
     the_query = db.query(gtfs_models.VehiclePosition).filter(getattr(gtfs_models.VehiclePosition,field_name) == field_value,gtfs_models.VehiclePosition.agency_id == agency_id).all()
     result = []
     for row in the_query:
-        row = vehicle_position_reformat(row)
-        result.append(row)
+        new_row = vehicle_position_reformat(row)
+        result.append(new_row)
     return result
 
 def get_gtfs_rt_trips_by_trip_id(db, trip_id: str,agency_id: str):
     the_query = db.query(gtfs_models.TripUpdate).filter(gtfs_models.TripUpdate.trip_id == trip_id,gtfs_models.TripUpdate.agency_id == agency_id).all()
     result = []
     for row in the_query:
-        row = trip_update_reformat(row)
-        result.append(row)
+        new_row = trip_update_reformat(row)
+        result.append(new_row)
     return result
 
 

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -42,7 +42,6 @@ def temp_solution(val):
 def list_gtfs_rt_trips_by_field_name(db, field_name: str,agency_id: str):
     result = []
     if field_name == 'stop_id':
-        print('in stop id field name')
         the_query = db.query(getattr(gtfs_models.StopTimeUpdate,field_name),gtfs_models.StopTimeUpdate.agency_id).with_entities(getattr(gtfs_models.StopTimeUpdate,field_name)).filter(gtfs_models.StopTimeUpdate.agency_id == agency_id).all()
     else:
         the_query = db.query(getattr(gtfs_models.TripUpdate,field_name),gtfs_models.TripUpdate.agency_id).with_entities(getattr(gtfs_models.TripUpdate,field_name)).filter(gtfs_models.TripUpdate.agency_id == agency_id).all()

--- a/fastapi/app/frontend/login.html
+++ b/fastapi/app/frontend/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Metro API 2.1.4</title>
+    <title>Metro API 2.1.5</title>
     <link rel="stylesheet" href="https://lacmta.github.io/design-system/dist/css/styles.css" type="text/css">
     <script src="https://lacmta.github.io/design-system/dist/js/uswds.min.js"></script>
     <script src="https://lacmta.github.io/design-system/dist/js/uswds-init.min.js"></script>

--- a/fastapi/app/gtfs_models.py
+++ b/fastapi/app/gtfs_models.py
@@ -3,6 +3,7 @@
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Boolean, Float, MetaData
 from sqlalchemy.orm import relationship, backref
+from sqlalchemy.dialects.postgresql import JSON
 from .config import Config
 
 GTFSrtBase = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
@@ -28,6 +29,7 @@ class TripUpdate(GTFSrtBase):
     agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
+    stop_time_json = Column(JSON)
     stop_time_updates = relationship('StopTimeUpdate', backref=backref('trip_updates',lazy="joined"))
     class Config:
         schema_extra = {
@@ -45,7 +47,7 @@ class StopTimeUpdate(GTFSrtBase):
     # oid = Column(Integer, )
 
     # TODO: Fill one from the other
-    # stop_sequence = Column(Integer)
+    stop_sequence = Column(Integer)
     stop_id = Column(String(10),primary_key=True)
     trip_id = Column(String, ForeignKey('trip_updates.trip_id'))
     arrival = Column(Integer)

--- a/fastapi/app/gtfs_models.py
+++ b/fastapi/app/gtfs_models.py
@@ -3,7 +3,7 @@
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, ForeignKey, Integer, String, DateTime, Boolean, Float, MetaData
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy.dialects.postgresql import JSON
+# from sqlalchemy.dialects.postgresql import JSON
 from .config import Config
 
 GTFSrtBase = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
@@ -29,7 +29,7 @@ class TripUpdate(GTFSrtBase):
     agency_id = Column(String)
     # moved from the header, and reformatted as datetime
     timestamp = Column(Integer)
-    stop_time_json = Column(JSON)
+    stop_time_json = Column(String)
     stop_time_updates = relationship('StopTimeUpdate', backref=backref('trip_updates',lazy="joined"))
     class Config:
         schema_extra = {

--- a/fastapi/app/utils/db_helper.py
+++ b/fastapi/app/utils/db_helper.py
@@ -29,9 +29,13 @@ def trip_update_reformat(row):
             if 'stop_squence' in stop_time:
                 this_stop_time['stopSequence'] = stop_time['stop_sequence']
             if 'arrival' in stop_time:
-                this_stop_time['arrival']['time'] = stop_time['arrival']
+                arrival = {}
+                arrival['time'] = stop_time['arrival']
+                this_stop_time['arrival'] = arrival
             if 'departure' in stop_time:
-                this_stop_time['departure']['time'] = stop_time['departure']
+                departure = {}
+                departure['time'] = stop_time['departure']
+                this_stop_time['departure'] = departure
             if 'schedule_relationship' in stop_time:
                 this_stop_time['scheduleRelationship'] = get_readable_schedule_relationship(stop_time['schedule_relationship'])
             if 'stop_id' in stop_time:

--- a/fastapi/app/utils/db_helper.py
+++ b/fastapi/app/utils/db_helper.py
@@ -1,3 +1,52 @@
+def trip_update_reformat(row):
+    
+    row['id'] = row.trip_id
+    trip_update = {}    
+    trip_update['timestamp'] = row.timestamp
+    del row.timestamp
+
+    trip = {}
+    if row.trip_id:
+        trip['tripid'] = row.trip_id
+        del row.trip_id
+    if row.start_time:
+        trip['startTime'] = row.start_time
+        del row.start_time
+    if row.start_date:
+        trip['startDate'] = row.start_date
+        del row.start_date
+    if row.schedule_relationship:
+        trip['scheduleRelationship'] = get_readable_schedule_relationship(row.schedule_relationship)
+        del row.schedule_relationship
+    if row.route_id:
+        trip['routeId'] = row.route_id
+        del row.route_id
+    if row.direction_id:
+        trip['directionId'] = row.direction_id
+        del row.direction_id
+    trip_update['trip'] = trip
+
+    stop_time_updates = []
+    if row.stop_time_json:
+        for stop_time in row.stop_time_json:
+            this_stop_time = {}
+            if stop_time['stop_squence']:
+                this_stop_time['stopSequence'] = stop_time['stop_sequence']
+            if stop_time['arrival']:
+                this_stop_time['arrival']['time'] = stop_time['arrival']
+            if stop_time['departure']:
+                this_stop_time['departure']['time'] = stop_time['departure']
+            if stop_time['schedule_relationship']:
+                this_stop_time['scheduleRelationship'] = get_readable_schedule_relationship(stop_time['schedule_relationship'])
+            if stop_time['stop_id']:
+                this_stop_time['stopId'] = stop_time['stop_id']
+            stop_time_updates.append(this_stop_time)
+    del row.stop_time_json
+    row["tripUpdate"] = trip_update
+    row["tripUpdate"]["stopTimeUpdate"] = stop_time_updates
+    return row
+
+
 def vehicle_position_reformat(row):
         trip_info = {}
         vehicle_info = {}
@@ -44,3 +93,13 @@ def get_readable_status(status):
         return 'STOPPED_AT'
     if status == 2:
         return 'IN_TRANSIT_TO'
+
+def get_readable_schedule_relationship(schedule_relationship):
+    if schedule_relationship == 0:
+        return 'SCHEDULED'
+    if schedule_relationship == 1:
+        return 'SKIPPED'
+    if schedule_relationship == 2:
+        return 'NO_DATA'
+    if schedule_relationship == 3:
+        return 'UNSCHEDULED'

--- a/fastapi/app/utils/db_helper.py
+++ b/fastapi/app/utils/db_helper.py
@@ -22,10 +22,9 @@ def trip_update_reformat(row):
 
     stop_time_updates = []
     
-    if row.stop_time_json:
+    if 'stop_time_json' in row:
         clean_stop_time_json = row.stop_time_json.replace("'", '"')
         for stop_time in json.loads(clean_stop_time_json):
-            print(stop_time)
             this_stop_time = {}
             if 'stop_squence' in stop_time:
                 this_stop_time['stopSequence'] = stop_time['stop_sequence']

--- a/fastapi/app/utils/db_helper.py
+++ b/fastapi/app/utils/db_helper.py
@@ -6,39 +6,40 @@ def trip_update_reformat(row):
     trip_update['timestamp'] = row.timestamp
 
     trip = {}
-    if 'trip_id' in row:
+    if row.trip_id:
         trip['tripid'] = row.trip_id
-    if 'start_time' in row:
+    if row.start_time:
         trip['startTime'] = row.start_time
-    if 'start_date' in row:
+    if row.start_date:
         trip['startDate'] = row.start_date
-    if 'schedule_relationship' in row:
+    if row.schedule_relationship:
         trip['scheduleRelationship'] = get_readable_schedule_relationship(row.schedule_relationship)
-    if 'route_id' in row:
+    if row.route_id:
         trip['routeId'] = row.route_id
-    if 'direction_id' in row:
+    if row.direction_id:
         trip['directionId'] = row.direction_id
     trip_update['trip'] = trip
 
     stop_time_updates = []
     
-    if 'stop_time_json' in row:
+    if row.stop_time_json:
         clean_stop_time_json = row.stop_time_json.replace("'", '"')
         for stop_time in json.loads(clean_stop_time_json):
             this_stop_time = {}
-            if 'stop_squence' in stop_time:
+            if stop_time['stop_sequence']:
                 this_stop_time['stopSequence'] = stop_time['stop_sequence']
-            if 'arrival' in stop_time:
+            if stop_time['arrival']:
                 arrival = {}
                 arrival['time'] = stop_time['arrival']
                 this_stop_time['arrival'] = arrival
-            if 'departure' in stop_time:
+            if stop_time['departure']:
                 departure = {}
                 departure['time'] = stop_time['departure']
                 this_stop_time['departure'] = departure
-            if 'schedule_relationship' in stop_time:
+                this_stop_time['departure']['time'] = stop_time['departure']
+            if stop_time['schedule_relationship']:
                 this_stop_time['scheduleRelationship'] = get_readable_schedule_relationship(stop_time['schedule_relationship'])
-            if 'stop_id' in stop_time:
+            if stop_time['stop_id']:
                 this_stop_time['stopId'] = stop_time['stop_id']
             stop_time_updates.append(this_stop_time)
     trip_update['stopTimeUpdates'] = stop_time_updates
@@ -51,31 +52,31 @@ def vehicle_position_reformat(row):
         vehicle_info = {}
         position_info = {}
 
-        if 'trip_id' in row:
+        if row.trip_id:
             trip_info['trip_id'] = row.trip_id
             del row.trip_id
-        if 'trip_route_id' in row:
+        if row.trip_route_id:
             trip_info['route_id'] = row.trip_route_id
             del row.trip_route_id
-        if 'trip_start_date' in row:
+        if row.trip_start_date:
             trip_info['trip_start_date'] = row.trip_start_date
             del row.trip_start_date      
-        if 'vehicle_id' in row:
+        if row.vehicle_id:
             vehicle_info['vehicle_id'] = row.vehicle_id
             del row.vehicle_id
-        if 'vehicle_label' in row:
+        if row.vehicle_label:
             vehicle_info['vehicle_label'] = row.vehicle_label
             del row.vehicle_label
-        if 'position_latitude' in row:
+        if row.position_latitude:
             position_info['latitude'] = row.position_latitude
             del row.position_latitude
-        if 'position_longitude' in row:
+        if row.position_longitude:
             position_info['longitude'] = row.position_longitude
             del row.position_longitude
-        if 'position_bearing' in row:
+        if row.position_bearing:
             position_info['bearing'] = row.position_bearing
             del row.position_bearing
-        if 'position_speed' in row:
+        if row.position_speed:
             position_info['speed'] = row.position_speed
             del row.position_speed
 

--- a/fastapi/app/utils/db_helper.py
+++ b/fastapi/app/utils/db_helper.py
@@ -1,36 +1,33 @@
+import json
 def trip_update_reformat(row):
-    
-    row['id'] = row.trip_id
+    result_row = {}
+    result_row['id'] = row.trip_id
     trip_update = {}    
     trip_update['timestamp'] = row.timestamp
-    del row.timestamp
 
     trip = {}
     if row.trip_id:
         trip['tripid'] = row.trip_id
-        del row.trip_id
     if row.start_time:
         trip['startTime'] = row.start_time
-        del row.start_time
     if row.start_date:
         trip['startDate'] = row.start_date
-        del row.start_date
     if row.schedule_relationship:
         trip['scheduleRelationship'] = get_readable_schedule_relationship(row.schedule_relationship)
-        del row.schedule_relationship
     if row.route_id:
         trip['routeId'] = row.route_id
-        del row.route_id
     if row.direction_id:
         trip['directionId'] = row.direction_id
-        del row.direction_id
     trip_update['trip'] = trip
 
     stop_time_updates = []
+    
     if row.stop_time_json:
-        for stop_time in row.stop_time_json:
+        clean_stop_time_json = row.stop_time_json.replace("'", '"')
+        for stop_time in json.loads(clean_stop_time_json):
+            print(stop_time)
             this_stop_time = {}
-            if stop_time['stop_squence']:
+            if stop_time['stop_sequence']:
                 this_stop_time['stopSequence'] = stop_time['stop_sequence']
             if stop_time['arrival']:
                 this_stop_time['arrival']['time'] = stop_time['arrival']
@@ -41,10 +38,9 @@ def trip_update_reformat(row):
             if stop_time['stop_id']:
                 this_stop_time['stopId'] = stop_time['stop_id']
             stop_time_updates.append(this_stop_time)
-    del row.stop_time_json
-    row["tripUpdate"] = trip_update
-    row["tripUpdate"]["stopTimeUpdate"] = stop_time_updates
-    return row
+    trip_update['stopTimeUpdates'] = stop_time_updates
+    result_row['tripUpdate'] = trip_update
+    return result_row
 
 
 def vehicle_position_reformat(row):

--- a/fastapi/app/utils/db_helper.py
+++ b/fastapi/app/utils/db_helper.py
@@ -6,17 +6,17 @@ def trip_update_reformat(row):
     trip_update['timestamp'] = row.timestamp
 
     trip = {}
-    if row.trip_id:
+    if 'trip_id' in row:
         trip['tripid'] = row.trip_id
-    if row.start_time:
+    if 'start_time' in row:
         trip['startTime'] = row.start_time
-    if row.start_date:
+    if 'start_date' in row:
         trip['startDate'] = row.start_date
-    if row.schedule_relationship:
+    if 'schedule_relationship' in row:
         trip['scheduleRelationship'] = get_readable_schedule_relationship(row.schedule_relationship)
-    if row.route_id:
+    if 'route_id' in row:
         trip['routeId'] = row.route_id
-    if row.direction_id:
+    if 'direction_id' in row:
         trip['directionId'] = row.direction_id
     trip_update['trip'] = trip
 
@@ -27,15 +27,15 @@ def trip_update_reformat(row):
         for stop_time in json.loads(clean_stop_time_json):
             print(stop_time)
             this_stop_time = {}
-            if stop_time['stop_sequence']:
+            if 'stop_squence' in stop_time:
                 this_stop_time['stopSequence'] = stop_time['stop_sequence']
-            if stop_time['arrival']:
+            if 'arrival' in stop_time:
                 this_stop_time['arrival']['time'] = stop_time['arrival']
-            if stop_time['departure']:
+            if 'departure' in stop_time:
                 this_stop_time['departure']['time'] = stop_time['departure']
-            if stop_time['schedule_relationship']:
+            if 'schedule_relationship' in stop_time:
                 this_stop_time['scheduleRelationship'] = get_readable_schedule_relationship(stop_time['schedule_relationship'])
-            if stop_time['stop_id']:
+            if 'stop_id' in stop_time:
                 this_stop_time['stopId'] = stop_time['stop_id']
             stop_time_updates.append(this_stop_time)
     trip_update['stopTimeUpdates'] = stop_time_updates
@@ -48,31 +48,31 @@ def vehicle_position_reformat(row):
         vehicle_info = {}
         position_info = {}
 
-        if row.trip_id:
+        if 'trip_id' in row:
             trip_info['trip_id'] = row.trip_id
             del row.trip_id
-        if row.trip_route_id:
+        if 'trip_route_id' in row:
             trip_info['route_id'] = row.trip_route_id
             del row.trip_route_id
-        if row.trip_start_date:
+        if 'trip_start_date' in row:
             trip_info['trip_start_date'] = row.trip_start_date
             del row.trip_start_date      
-        if row.vehicle_id:
+        if 'vehicle_id' in row:
             vehicle_info['vehicle_id'] = row.vehicle_id
             del row.vehicle_id
-        if row.vehicle_label:
+        if 'vehicle_label' in row:
             vehicle_info['vehicle_label'] = row.vehicle_label
             del row.vehicle_label
-        if row.position_latitude:
+        if 'position_latitude' in row:
             position_info['latitude'] = row.position_latitude
             del row.position_latitude
-        if row.position_longitude:
+        if 'position_longitude' in row:
             position_info['longitude'] = row.position_longitude
             del row.position_longitude
-        if row.position_bearing:
+        if 'position_bearing' in row:
             position_info['bearing'] = row.position_bearing
             del row.position_bearing
-        if row.position_speed:
+        if 'position_speed' in row:
             position_info['speed'] = row.position_speed
             del row.position_speed
 


### PR DESCRIPTION
### Change log 
feat: [data-loading] joined stop times as string
feat: [api] added data reformatting function

got data to return in the following format as per #5 
```
[

    {
        "id": "10051003271804-SEPT22",
        "tripUpdate": {
            "timestamp": 1666842051,
            "trip": {
                "tripid": "10051003271804-SEPT22",
                "startTime": "18:04:00",
                "startDate": "20221027",
                "routeId": "51-13164",
                "directionId": 1
            },
            "stopTimeUpdates": [
                {
                    "stopSequence": 14,
                    "scheduleRelationship": "SKIPPED",
                    "stopId": "9751"
                },
                {
                    "stopSequence": 15,
                    "scheduleRelationship": "SKIPPED",
                    "stopId": "9763"
                }
            ]
        }
    }

]
```

Needs to be checked.