### PR TITLE
Hotfix: correct `gtfs-rt-endpoints`

### DIFF
--- a/data-loading-service/app/utils/gtfs_rt_helper.py
+++ b/data-loading-service/app/utils/gtfs_rt_helper.py
@@ -142,11 +142,11 @@ def update_gtfs_realtime_data():
                 'agency_id': agency,
                 'timestamp': entity.trip_update.timestamp
             })
-        stop_time_df = pd.DataFrame(stop_time_array).astype({'arrival': 'int8', 'departure': 'int8', 'stop_sequence': 'int8', 'schedule_relationship': 'int8'})
+        stop_time_df = pd.DataFrame(stop_time_array)
         del stop_time_array
         # stop_time_df = pd.DataFrame(stop_time_array, columns=['trip_id', 'stop_id', 'arrival', 'departure', 'stop_sequence', 'agency_id', 'schedule_relationship'], dtype='[string, string, int8, int8, int8, string, int8]')
         combined_stop_time_dataframes.append(stop_time_df)
-        trip_update_df = pd.DataFrame(trip_update_array).astype({'direction_id': 'int8', 'schedule_relationship': 'int8'})
+        trip_update_df = pd.DataFrame(trip_update_array)
         del trip_update_array
         combined_trip_update_dataframes.append(trip_update_df)
 

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -171,14 +171,14 @@ def get_gtfs_rt_vehicle_positions_trip_data(db,vehicle_id: str,geojson:bool,agen
         return this_json
     for row in the_query:
         if row.trip_id is None:
-            return 'No trip data for this vehicle'
+            return 'No trip data for this vehicle' + str(stop_id)
         new_row = vehicle_position_reformat_for_trip_details(row,geojson)
         stop_name_query = db.query(models.Stops.stop_name).filter(models.Stops.stop_id == new_row.stop_id,models.Stops.agency_id == agency_id).first()
-        new_row.stop_name = stop_name_query['stop_name'][0]
+        new_row.stop_name = stop_name_query['stop_name']
         upcoming_stop_time_update_query = db.query(gtfs_models.StopTimeUpdate).filter(gtfs_models.StopTimeUpdate.trip_id == new_row.trip_id,gtfs_models.StopTimeUpdate.stop_sequence == new_row.current_stop_sequence).first()
-        new_row.upcoming_stop_time_update = upcoming_stop_time_update_query
+        new_row.upcoming_stop_time_update = upcoming_stop_time_reformat(upcoming_stop_time_update_query)
         route_code_query = db.query(models.StopTimes.route_code).filter(models.StopTimes.trip_id == new_row.trip_id,models.StopTimes.stop_sequence == new_row.current_stop_sequence).first()
-        new_row.route_code = route_code_query['route_code'][0]
+        new_row.route_code = route_code_query['route_code']
         result.append(new_row)
     return result
 

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -445,7 +445,6 @@ def read_user(username: str, db: Session = Depends(get_db),token: str = Depends(
 
 @app.on_event("startup")
 async def startup_event():
-    print("Starting up...")
     uvicorn_access_logger = logging.getLogger("uvicorn.access")
     uvicorn_error_logger = logging.getLogger("uvicorn.error")
     logger = logging.getLogger("uvicorn.app")

--- a/fastapi/app/utils/db_helper.py
+++ b/fastapi/app/utils/db_helper.py
@@ -155,6 +155,24 @@ def vehicle_position_reformat_for_trip_details(row,geojson=False):
         row.position = position_info
         return row
 
+def upcoming_stop_time_reformat(stop_time_update):
+    if stop_time_update != None:
+        if stop_time_update.trip_updates:
+            sanitized_stop_time_json = stop_time_update.trip_updates.stop_time_json.replace("'", '"')
+            update_json = json.loads(sanitized_stop_time_json)
+            for row in update_json:
+                new_stop_time_object = {}
+                print(row)
+                if row['stop_sequence'] == stop_time_update.stop_sequence:
+                    if row['arrival']:
+                        new_stop_time_object['arrival'] = row['arrival']
+                    if row['departure']:
+                        new_stop_time_object['departure'] = row['departure']
+                    new_stop_time_object['schedule_relationship'] = get_readable_schedule_relationship(row['schedule_relationship'])
+                    new_stop_time_object['stop_id'] = row['stop_id']
+                    new_stop_time_object['stop_sequence'] = row['stop_sequence']
+                    return new_stop_time_object
+            
 def get_readable_status(status):
     if status == 0:
         return 'INCOMING_AT'


### PR DESCRIPTION
Closes #130 

### Change log
 - [api] created new function to clean up `upcoming_stop_time` data
 - [data-loading] `-1` value for empty `stop_sequences`
 - [api] in the `trip_detail` endpoint's `upcoming_stop_time_update`,  the `arrival` or `departure` field only shows up if there is a value for it

### Testing

The endpoint was tested on `http://localhost/LACMTA/trip_detail/5877?geojson=false`

``` json
[
  {
    "trip_start_date": "20221222",
    "current_status": "IN_TRANSIT_TO",
    "stop_id": "6147",
    "geometry": {
      "type": "Point",
      "coordinates": [
        -118.46610260009766,
        34.21665573120117
      ]
    },
    "vehicle_label": "5877",
    "timestamp": 1671758729,
    "trip_id": "10234000731655-DEC22",
    "current_stop_sequence": 20,
    "agency_id": "LACMTA",
    "trip_assigned": true,
    "position": {
      "latitude": 34.21665573120117,
      "longitude": -118.46610260009766
    },
    "stop_name": "Sepulveda / Lanark",
    "upcoming_stop_time_update": {
      "arrival": 1671758788,
      "schedule_relationship": "",
      "stop_id": "6147",
      "stop_sequence": 20
    },
    "route_code": "234"
  }
]
```