### PR TITLE
2.1.25 - [Hot Fix] geojson websocket endpoint

### DIFF
--- a/data-loading-service/app/config.py
+++ b/data-loading-service/app/config.py
@@ -36,7 +36,7 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.1.24"
+    CURRENT_VERSION = "2.1.25"
     # API_LAST_UPDATE_TIME = os.path.getmtime(r'main.py')
     LOGZIO_TOKEN = os.environ.get('LOGZIO_TOKEN')
     LOGZIO_URL = os.environ.get('LOGZIO_URL')

--- a/fastapi/app/config.py
+++ b/fastapi/app/config.py
@@ -25,7 +25,7 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.1.24"
+    CURRENT_VERSION = "2.1.25"
     API_LAST_UPDATE_TIME = os.path.getmtime(r'app/main.py')
     LOGZIO_TOKEN = os.environ.get('LOGZIO_TOKEN')
     LOGZIO_URL = os.environ.get('LOGZIO_URL')

--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -257,7 +257,7 @@ async def get_gtfs_rt_vehicle_positions_trip_data_by_route_code_for_async(sessio
                         upcoming_update = upcoming_stop_time_reformat_for_async(upcoming_stop_time_update_query.scalars().first())
                         if upcoming_update:
                             new_geojson['properties']['trip']['upcoming_stop_time_update'] = upcoming_update
-                            trip_details_query = await session.execute(select(gtfs_models.TripUpdate).where(gtfs_models.TripUpdate.trip_id == new_row_trip_id))
+                            trip_details_query = await session.execute(select(gtfs_models.TripUpdate).where(gtfs_models.TripUpdate.trip_id == geojson_trip_id))
                             new_geojson['properties']['trip']['direction_id'] = trip_details_query.scalar().direction_id                            
                         route_code_query = await session.execute(select(models.StopTimes.route_code).where(models.StopTimes.trip_id == geojson_trip_id,models.StopTimes.stop_sequence == geojson_current_stop_sequence))
                         destination_code_query = await session.execute(select(models.StopTimes.destination_code).where(models.StopTimes.trip_id == geojson_trip_id,models.StopTimes.stop_sequence == geojson_current_stop_sequence))
@@ -279,21 +279,17 @@ async def get_gtfs_rt_vehicle_positions_trip_data_by_route_code_for_async(sessio
             if new_row['trip']['stop_id']:
                 this_stop_id = new_row['trip']['stop_id']
                 stop_name_query = await session.execute(select(models.Stops.stop_name).where(models.Stops.stop_id == this_stop_id,models.Stops.agency_id == agency_id))
-                # stop_name_query = db.select(models.Stops.stop_name).filter(models.Stops.stop_id == new_row.stop_id,models.Stops.agency_id == agency_id).first()
                 new_row['stop_name'] = stop_name_query.scalar()
                 new_row_current_stop_sequence = new_row['trip']['current_stop_sequence']
                 new_row_trip_id = new_row['trip']['trip_id']
                 upcoming_stop_time_update_query = await session.execute(select(gtfs_models.StopTimeUpdate).where(gtfs_models.StopTimeUpdate.trip_id == new_row_trip_id,gtfs_models.StopTimeUpdate.stop_sequence == new_row_current_stop_sequence))
-                # upcoming_stop_time_update_query = db.select(gtfs_models.StopTimeUpdate).filter(gtfs_models.StopTimeUpdate.trip_id == new_row.trip_id,gtfs_models.StopTimeUpdate.stop_sequence == new_row.current_stop_sequence).first()
                 if upcoming_stop_time_update_query is not None:
                     new_row['trip_assigned'] = True
                     trip_details_query = await session.execute(select(gtfs_models.TripUpdate).where(gtfs_models.TripUpdate.trip_id == new_row_trip_id))
                     new_row['direction_id'] = trip_details_query.scalar().direction_id
                 new_row['upcoming_stop_time_update'] = upcoming_stop_time_reformat(upcoming_stop_time_update_query.scalars().first())
                 route_code_query = await session.execute(select(models.StopTimes.route_code).where(models.StopTimes.trip_id == new_row_trip_id,models.StopTimes.stop_sequence == new_row_current_stop_sequence))
-                # route_code_query = db.select(models.StopTimes.route_code).filter(models.StopTimes.trip_id == new_row.trip_id,models.StopTimes.stop_sequence == new_row.current_stop_sequence).first()
                 destination_code_query = await session.execute(select(models.StopTimes.destination_code).where(models.StopTimes.trip_id == new_row_trip_id,models.StopTimes.stop_sequence == new_row_current_stop_sequence))
-                # destination_code_query = db.select(models.StopTimes.destination_code).filter(models.StopTimes.trip_id == new_row.trip_id,models.StopTimes.stop_sequence == new_row.current_stop_sequence).first()
                 new_row['route_code'] = route_code_query.scalar()
                 new_row['destination_code'] = destination_code_query.scalar()
                 result.append(new_row)

--- a/fastapi/app/frontend/login.html
+++ b/fastapi/app/frontend/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Metro API 2.1.24</title>
+    <title>Metro API 2.1.25</title>
     <link rel="stylesheet" href="https://lacmta.github.io/design-system/dist/css/styles.css" type="text/css">
     <script src="https://lacmta.github.io/design-system/dist/js/uswds.min.js"></script>
     <script src="https://lacmta.github.io/design-system/dist/js/uswds-init.min.js"></script>

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -425,7 +425,7 @@ async def get_time():
 
 # @app.get("/agencies/")
 # async def root():
-#     return {"Metro API Version": "2.1.24"}
+#     return {"Metro API Version": "2.1.25"}
 
 # WebSockets
 import random


### PR DESCRIPTION
Hotfix for getting the geojson websocket working with `direction_id`:

`direction_id` can be found in the `properties`-> `trip` object:

```js
      {
         "type": "Feature",
         "geometry": {
            "type": "Point",
            "coordinates": [
               -118.46089172363281,
               34.04934310913086
            ]
         },
         "properties": {
            "trip": {
               "trip_assigned": true,
               "trip_id": "10720012921535-DEC22",
               "trip_start_date": "20230602",
               "current_stop_sequence": 8,
               "trip_route_id": "720-13167",
               "stop_id": "104707",
               "vehicle_id": "8833",
               "upcoming_stop_time_update": {
                  "arrival": 1685746806,
                  "schedule_relationship": "",
                  "stop_id": "104707",
                  "stop_sequence": 8
               },
               "direction_id": 0,
               "route_code": "720",
               "destination_code": "Downtown LA - 6th - Central"
            },
            "position": {
               "timestamp": 1685746854,
               "latitude": 34.04934310913086,
               "longitude": -118.46089172363281,
               "position_bearing": 46.612735748291016
            },
            "current_status": "STOPPED_AT",
            "trip_assigned": true,
            "stop_name": "Wilshire / Barrington"
         }
```

### Change log

fix: [api] geojson websocket endpoint
remove: [api] websockets /live/trip_detail/route_code/`

