### PR TITLE
Add execute permission for replace_secrets.sh script

### DIFF
--- a/.github/workflows/dev-aws.yml
+++ b/.github/workflows/dev-aws.yml
@@ -41,6 +41,9 @@ jobs:
           echo HASH_KEY=${{ secrets.HASH_KEY }} >> $GITHUB_ENV
           echo HASHING_ALGORITHM=${{ secrets.HASHING_ALGORITHM }} >> $GITHUB_ENV
           echo LOGZIO_TOKEN=${{ secrets.LOGZIO_TOKEN }} >> $GITHUB_ENV
+      - name: Set execute permissions for script
+        run: chmod +x replace_secrets.sh
+
       - name: Replace placeholders in JSON files
         run: ./replace_secrets.sh
       - name: Upgrade AWS CLI version and setup lightsailctl


### PR DESCRIPTION
This pull request adds execute permission for the replace_secrets.sh script, which is necessary for it to run properly during the deployment process. This change ensures that the script can be executed without any issues and that the placeholders in the JSON files are properly replaced with the corresponding secrets.