### PR TITLE
Fix to use `aioredis.from_url` instead of connection pool

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -48,7 +48,6 @@ from starlette.responses import Response
 
 # from redis import asyncio as aioredis
 from enum import Enum
-from aioredis import create_redis_pool
 
 
 # for OAuth2
@@ -87,7 +86,7 @@ async def initialize_redis():
     logging.info(f"Connecting to Redis at {Config.REDIS_URL}")
     for i in range(5):  # Retry up to 5 times
         try:
-            redis = await create_redis_pool(Config.REDIS_URL)
+            redis = await aioredis.from_url(Config.REDIS_URL)
             break  # If the connection is successful, break out of the loop
         except aioredis.exceptions.ConnectionError as e:
             logging.error(f"Failed to connect to Redis: {e}")
@@ -739,7 +738,7 @@ async def get_all_routes():
 
 @app.on_event("startup")
 async def startup_event():
-    redis_pool = await create_redis_pool(Config.REDIS_URL)
+    redis_pool = await aioredis.from_url(Config.REDIS_URL)
     redis = RedisBackend(redis_pool)
     FastAPICache.init(backend=redis, prefix="fastapi-cache")
     uvicorn_access_logger = logging.getLogger("uvicorn.access")


### PR DESCRIPTION
This PR is required to get the app to run.