### PR TITLE
Fix typo in import statement

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -18,7 +18,7 @@ import pytz
 
 from datetime import timedelta, date, datetime
 
-from fastapi import FastAPI, Request, Response, Depends, HTTPException, status, Query, Websocket,WebSocketDisconnect
+from fastapi import FastAPI, Request, Response, Depends, HTTPException, status, Query, WebSocket,WebSocketDisconnect
 from fastapi import Path as FastAPIPath
 # from fastapi import FastAPI, Request, Response, Depends, HTTPException, status
 from fastapi.encoders import jsonable_encoder


### PR DESCRIPTION
This pull request fixes a typo in the import statement of the code. The import statement for the `WebSocket` class was incorrectly spelled as `Websocket`. This PR corrects the spelling to `WebSocket` to ensure proper functionality.

Please let me know if you need any further assistance.