### PR TITLE
Update number of workers in Dockerfile

### DIFF
--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -45,5 +45,5 @@ print(f'export DB_NAME={result.path[1:]}')" > /tmp/env.sh && \
     echo "auth_file = /etc/pgbouncer/userlist.txt" >> /etc/pgbouncer/pgbouncer.ini && \
     echo "client_login_timeout = 120" >> /etc/pgbouncer/pgbouncer.ini && \
     gosu pgbouncer pgbouncer /etc/pgbouncer/pgbouncer.ini & \
-    exec uvicorn app.main:app --host 0.0.0.0 --port 80 --workers 2
+    exec uvicorn app.main:app --host 0.0.0.0 --port 80 --workers 4
 EXPOSE 80


### PR DESCRIPTION
This pull request updates the number of workers in the Dockerfile from 2 to 4. Increasing the number of workers can improve the performance and scalability of the application. This change ensures that the application can handle a higher number of concurrent requests.

Fixes #1234