### PR TITLE
Refactor CRUD functions to use async/await

### DIFF
--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -45,5 +45,5 @@ print(f'export DB_NAME={result.path[1:]}')" > /tmp/env.sh && \
     echo "auth_file = /etc/pgbouncer/userlist.txt" >> /etc/pgbouncer/pgbouncer.ini && \
     echo "client_login_timeout = 120" >> /etc/pgbouncer/pgbouncer.ini && \
     gosu pgbouncer pgbouncer /etc/pgbouncer/pgbouncer.ini & \
-    exec uvicorn app.main:app --host 0.0.0.0 --port 80 --workers 4
+    exec uvicorn app.main:app --host 0.0.0.0 --port 80 --workers 2
 EXPOSE 80

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -825,15 +825,15 @@ async def startup_event():
         logger = logging.getLogger("uvicorn.app")
         logzio_formatter = logging.Formatter("%(message)s")
         logzio_uvicorn_access_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'uvicorn.access', 5, Config.LOGZIO_URL)
-        logzio_uvicorn_access_handler.setLevel(logging.INFO)
+        logzio_uvicorn_access_handler.setLevel(logging.WARNING)
         logzio_uvicorn_access_handler.setFormatter(logzio_formatter)
 
         logzio_uvicorn_error_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'uvicorn.error', 5, Config.LOGZIO_URL)
-        logzio_uvicorn_error_handler.setLevel(logging.INFO)
+        logzio_uvicorn_error_handler.setLevel(logging.WARNING)
         logzio_uvicorn_error_handler.setFormatter(logzio_formatter)
 
         logzio_app_handler = LogzioHandler(Config.LOGZIO_TOKEN, 'fastapi.app', 5, Config.LOGZIO_URL)
-        logzio_app_handler.setLevel(logging.INFO)
+        logzio_app_handler.setLevel(logging.WARNING)
         logzio_app_handler.setFormatter(logzio_formatter)
 
         uvicorn_access_logger.addHandler(logzio_uvicorn_access_handler)

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -501,8 +501,8 @@ async def get_trip_detail_by_route(agency_id: AgencyIdEnum, route_code: Optional
 
 @app.get("/canceled_service_summary",tags=["Canceled Service Data"])
 @cache(expire=CANCELED_UDPATE_INTERVAL)
-async def get_canceled_trip_summary(db: Session = Depends(get_db)):
-    result = crud.get_canceled_trips(db,'all')
+async def get_canceled_trip_summary(db: AsyncSession = Depends(get_async_db)):
+    result = await crud.get_canceled_trips(db,'all')
     canceled_trips_summary = {}
     total_canceled_trips = 0
     canceled_trip_json = jsonable_encoder(result)
@@ -512,7 +512,6 @@ async def get_canceled_trip_summary(db: Session = Depends(get_db)):
                 "last_update": ""}
     else:
         for trip in canceled_trip_json:
-            # route_number = standardize_string(trip["trp_route"])
             route_number = standardize_string(trip["trp_route"])
             if route_number:
                 if route_number not in canceled_trips_summary:
@@ -683,12 +682,12 @@ async def get_agency(agency_id: AgencyIdEnum, db: Session = Depends(get_db)):
 
 @app.get("/get_gopass_schools",tags=["Other data"])
 @cache(expire=GO_PASS_UPDATE_INTERVAL)
-async def get_gopass_schools(db: Session = Depends(get_db),show_missing: bool = False,combine_phone:bool = False,groupby_column:GoPassGroupEnum = None):
+async def get_gopass_schools(db: AsyncSession = Depends(get_async_db), show_missing: bool = False, combine_phone:bool = False, groupby_column:GoPassGroupEnum = None):
     if combine_phone == True:
-        result = crud.get_gopass_schools_combined_phone(db,groupby_column.value)
+        result = await crud.get_gopass_schools_combined_phone(db, groupby_column.value)
         return result
     else:
-        result = crud.get_gopass_schools(db,show_missing)
+        result = await crud.get_gopass_schools(db, show_missing)
         json_compatible_item_data = jsonable_encoder(result)
     return JSONResponse(content=json_compatible_item_data)
 


### PR DESCRIPTION
This pull request refactors the CRUD functions in the codebase to use async/await instead of synchronous operations. This improves the performance and responsiveness of the application by allowing concurrent execution of database queries. The affected functions include `get_canceled_trips` and `get_gopass_schools_combined_phone`. Additionally, the `get_canceled_trip_summary` and `get_gopass_schools` endpoints have been updated to use the new async versions of these functions.

This pull request also include these changes:

- Refactored some CRUD functions to use async/await for better asynchronous handling.

- Updated the UVicorn worker count to 2 for improved concurrency.

- Added a middleware to block repeated requests and prevent abuse.

- Reduced logging to improve performance.

These changes aim to enhance the overall performance and efficiency of the application. No new features or bug fixes are included in this pull request.
