### PR TITLE
Update Dockerfile to use gunicorn with UvicornWorker for scaling out

### DIFF
--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -45,5 +45,5 @@ print(f'export DB_NAME={result.path[1:]}')" > /tmp/env.sh && \
     echo "auth_file = /etc/pgbouncer/userlist.txt" >> /etc/pgbouncer/pgbouncer.ini && \
     echo "client_login_timeout = 120" >> /etc/pgbouncer/pgbouncer.ini && \
     gosu pgbouncer pgbouncer /etc/pgbouncer/pgbouncer.ini & \
-    exec uvicorn app.main:app --host 0.0.0.0 --port 80 --workers 2
+    exec gunicorn -k uvicorn.workers.UvicornWorker app.main:app --bind 0.0.0.0:80 --workers 2
 EXPOSE 80


### PR DESCRIPTION
This pull request updates the Dockerfile to use gunicorn with UvicornWorker for scaling out the application. This change improves the performance and scalability of the application by utilizing multiple workers. The Dockerfile has been modified to use the `gunicorn` command with the `-k uvicorn.workers.UvicornWorker` option, binding the application to `0.0.0.0:80` and using 2 workers.
