### PR TITLE
Remove rate limit middleware

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -269,7 +269,7 @@ inspector = inspect(engine)
 from sqlalchemy import Table
 
 app = FastAPI(openapi_tags=tags_metadata,docs_url="/")
-app.add_middleware(RateLimitMiddleware, limit=100, interval=60)
+# app.add_middleware(RateLimitMiddleware, limit=100, interval=60)
 
 # db = connect(host=''ort=0, timeout=None, source_address=None)
 


### PR DESCRIPTION
This pull request removes the rate limit middleware that was previously added to the FastAPI application. The middleware was commented out in the code.
