### PR TITLE
Re-add ratelimiting

### DIFF
--- a/fastapi/Dockerfile
+++ b/fastapi/Dockerfile
@@ -44,6 +44,8 @@ print(f'export DB_NAME={result.path[1:]}')" > /tmp/env.sh && \
     echo "auth_type = md5" >> /etc/pgbouncer/pgbouncer.ini && \
     echo "auth_file = /etc/pgbouncer/userlist.txt" >> /etc/pgbouncer/pgbouncer.ini && \
     echo "client_login_timeout = 120" >> /etc/pgbouncer/pgbouncer.ini && \
+    echo "pool_size = 30" >> /etc/pgbouncer/pgbouncer.ini && \
+    echo "query_wait_timeout = 300" >> /etc/pgbouncer/pgbouncer.ini && \
     gosu pgbouncer pgbouncer /etc/pgbouncer/pgbouncer.ini & \
     exec uvicorn app.main:app --host 0.0.0.0 --port 80 --workers 2
 EXPOSE 80

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -269,7 +269,7 @@ inspector = inspect(engine)
 from sqlalchemy import Table
 
 app = FastAPI(openapi_tags=tags_metadata,docs_url="/")
-# app.add_middleware(RateLimitMiddleware, limit=100, interval=60)
+app.add_middleware(RateLimitMiddleware, limit=100, interval=60)
 
 # db = connect(host=''ort=0, timeout=None, source_address=None)
 


### PR DESCRIPTION
This pull request re-adds the ratelimiting feature that was previously removed. The `RateLimitMiddleware` middleware is added to the `app` instance in order to limit the number of requests to 100 per minute.