### PR TITLE
Add cache_expiration parameter to get_data_async function

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -399,7 +399,7 @@ async def get_all_vehicle_positions(agency_id: AgencyIdEnum, format: FormatEnum 
     Get all vehicle positions updates.
     """
     model = models.VehiclePositions
-    data = await crud.get_all_data_async(async_db, model, agency_id.value)
+    data = await crud.get_all_data_async(async_db, model, agency_id.value, cache_expiration=8)
     if data is None:
         raise HTTPException(status_code=404, detail="Data not found")
     if format == FormatEnum.geojson:
@@ -504,7 +504,7 @@ async def websocket_vehicle_positions_by_ids(websocket: WebSocket, agency_id: Ag
 
 @app.get("/{agency_id}/trip_detail/route_code/{route_code}",tags=["Real-Time data"])
 async def get_trip_detail_by_route_code(agency_id: AgencyIdEnum, route_code: str, geojson:bool=False, db: AsyncSession = Depends(get_db)):
-    result = await crud.get_gtfs_rt_vehicle_positions_trip_data_by_route_code(session=db, route_code=route_code, geojson=geojson, agency_id=agency_id.value)
+    result = await crud.get_gtfs_rt_vehicle_positions_trip_data_by_route_code_for_async(session=db, route_code=route_code, geojson=geojson, agency_id=agency_id.value)
     return result
 
 @app.get("/{agency_id}/trip_detail/vehicle/{vehicle_id?}", tags=["Real-Time data"])


### PR DESCRIPTION
This pull request adds a new optional parameter, `cache_expiration`, to the `get_data_async` function in order to allow the user to specify the expiration time for caching the query result in Redis. This parameter will be used to set the expiration time for the cached data. The default value is `None`, which means the data will not be cached. This enhancement improves the performance of the function by reducing the number of database queries when the same query is executed multiple times within the specified expiration time.
