### PR TITLE
Add handling for missing 'trip_id' key in to_geojson function

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -274,10 +274,13 @@ from shapely import wkt
 def to_geojson(data):
     features = []
     for item in data:
+        # Check if trip_id is None before trying to access it
+        if item.trip_id is None:
+            continue  # skip this item
         # Create a Point from the 'geometry' coordinates
-        geometry = Point(item['geometry']['coordinates'])
+        geometry = Point((item.geometry.longitude, item.geometry.latitude))
         # Exclude the 'geometry' key from the properties
-        properties = {key: item[key] for key in item if key != 'geometry'}
+        properties = {key: getattr(item, key) for key in dir(item) if not key.startswith('_') and key != 'geometry'}
         feature = Feature(geometry=geometry, properties=properties)
         features.append(feature)
     feature_collection = FeatureCollection(features)

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -274,13 +274,13 @@ from shapely import wkt
 def to_geojson(data):
     features = []
     for item in data:
-        # Check if trip_id is None before trying to access it
-        if item.trip_id is None:
+        # Check if 'trip_id' is in the dictionary before trying to access it
+        if 'trip_id' not in item or item['trip_id'] is None:
             continue  # skip this item
         # Create a Point from the 'geometry' coordinates
-        geometry = Point((item.geometry.longitude, item.geometry.latitude))
+        geometry = Point(item['geometry']['coordinates'])
         # Exclude the 'geometry' key from the properties
-        properties = {key: getattr(item, key) for key in dir(item) if not key.startswith('_') and key != 'geometry'}
+        properties = {key: value for key, value in item.items() if key != 'geometry'}
         feature = Feature(geometry=geometry, properties=properties)
         features.append(feature)
     feature_collection = FeatureCollection(features)
@@ -290,7 +290,6 @@ def to_geojson(data):
         'timestamp': datetime.now().isoformat()
     }
     return feature_collection
-
 # code from https://fastapi-restful.netlify.app/user-guide/repeated-tasks/
 
 def csv_to_json(csvFilePath, jsonFilePath):


### PR DESCRIPTION
This pull request adds a new feature to the to_geojson function in order to handle cases where the 'trip_id' key is missing in the input data. Previously, the function would throw an error if the 'trip_id' key was None, but now it checks if the key is present in the dictionary before accessing it. If the key is missing or its value is None, the item is skipped.

This change improves the robustness of the to_geojson function and ensures that it can handle a wider range of input data. It also helps to prevent potential errors and crashes when processing data that may have missing or incomplete information.
