### PR TITLE
Fix isinstance check for RouteStopsGrouped

### DIFF
--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -170,7 +170,7 @@ async def get_data_async(async_session: Session, model: Type[DeclarativeMeta], a
 
     # Convert WKBElement to a serializable format
     for item in data:
-        if isinstance(item, models.RouteOverview):
+        if isinstance(item, models.RouteStopsGrouped):
             if hasattr(item, 'shape_direction_0') and item.shape_direction_0 is not None:
                 item.shape_direction_0 = mapping(load_wkb(item.shape_direction_0.desc))
             if hasattr(item, 'shape_direction_1') and item.shape_direction_1 is not None:


### PR DESCRIPTION
This pull request fixes the isinstance check for RouteStopsGrouped in the get_data_async function. Previously, it was incorrectly checking for RouteOverview instead of RouteStopsGrouped. This fix ensures that the correct check is performed, allowing the function to work as intended.