### PR TITLE
Refactor RouteStopsGrouped class to inherit from BaseModel

### DIFF
--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -154,7 +154,7 @@ class RouteStops(Base):
     # longitude = Column(Float)
     agency_id = Column(String)
 
-class RouteStopsGrouped(Base):
+class RouteStopsGrouped(BaseModel):
     __tablename__ = "route_stops_grouped"
     route_code = Column(String,primary_key=True, index=True)
     payload = Column(JSON)


### PR DESCRIPTION
This pull request refactors the RouteStopsGrouped class to inherit from the BaseModel class. This change enables the geometry field to be correctly used as it adds the `to_dict` method.