### PR TITLE
Refactor sleep durations in websocket_endpoint function

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -568,7 +568,7 @@ async def websocket_endpoint(websocket: WebSocket, agency_id: str):
                     # Publish the data
                     if data is not None:
                         await redis.publish(f'vehicle_positions_{agency_id}', json.dumps(data))
-                    await asyncio.sleep(4)  # Sleep for 3.6 seconds
+                    await asyncio.sleep(5)  # Sleep for 3.6 seconds
                 except Exception as e:
                     print(f"Error: {str(e)}")
         # Start the publisher and reader as separate tasks

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -539,7 +539,7 @@ async def websocket_endpoint(websocket: WebSocket, agency_id: str):
                                         await websocket.send_text(json.dumps(item))
                                 except Exception as e:
                                     await websocket.send_text(f"Error: {str(e)}")
-                        await asyncio.sleep(3)
+                        await asyncio.sleep(1.5)
                 except asyncio.TimeoutError:
                     pass
 
@@ -568,7 +568,7 @@ async def websocket_endpoint(websocket: WebSocket, agency_id: str):
                     # Publish the data
                     if data is not None:
                         await redis.publish(f'vehicle_positions_{agency_id}', json.dumps(data))
-                    await asyncio.sleep(5)  # Sleep for 3.6 seconds
+                    await asyncio.sleep(4)  # Sleep for 3.6 seconds
                 except Exception as e:
                     print(f"Error: {str(e)}")
         # Start the publisher and reader as separate tasks


### PR DESCRIPTION
This pull request refactors the sleep durations in the `websocket_endpoint` function to improve performance. The sleep time has been reduced from 3 seconds to 1.5 seconds.