### PR TITLE
Add GTFS-RT trip updates websocket endpoints

### DIFF
--- a/data-loading-service/app/utils/gtfs_rt_helper.py
+++ b/data-loading-service/app/utils/gtfs_rt_helper.py
@@ -131,8 +131,8 @@ async def update_gtfs_realtime_data():
     websocket_endpoints = [
     'wss://api.metro.net/ws/LACMTA_Rail/vehicle_positions',
     'wss://api.metro.net/ws/LACMTA/vehicle_positions',
-    'wss://api.metro.net/ws/LACMTA_Rail/trip_details',
-    'wss://api.metro.net/ws/LACMTA/trip_details'
+    'wss://api.metro.net/ws/LACMTA_Rail/trip_updates',
+    'wss://api.metro.net/ws/LACMTA/trip_updates'
     ]
 
     for endpoint in websocket_endpoints:


### PR DESCRIPTION
This pull request adds two new GTFS-RT websocket endpoints for trip updates. The new endpoints are 'wss://api.metro.net/ws/LACMTA_Rail/trip_updates' and 'wss://api.metro.net/ws/LACMTA/trip_updates'. These endpoints will provide real-time updates for trip information.