### PR TITLE
Fix unnecessary database configuration statements

### DIFF
--- a/data-loading-service/app/utils/gtfs_rt_helper.py
+++ b/data-loading-service/app/utils/gtfs_rt_helper.py
@@ -131,8 +131,8 @@ async def update_gtfs_realtime_data():
     websocket_endpoints = [
     'wss://api.metro.net/ws/LACMTA_Rail/vehicle_positions',
     'wss://api.metro.net/ws/LACMTA/vehicle_positions',
-    'wss://api.metro.net/ws/LACMTA_Rail/trip_details',
-    'wss://api.metro.net/ws/LACMTA/trip_details'
+    'wss://api.metro.net/ws/LACMTA_Rail/trip_updates',
+    'wss://api.metro.net/ws/LACMTA/trip_updates'
     ]
 
     for endpoint in websocket_endpoints:

--- a/fastapi/app/database.py
+++ b/fastapi/app/database.py
@@ -29,9 +29,6 @@ Base = declarative_base(metadata=MetaData(schema=Config.TARGET_DB_SCHEMA))
 def get_db():
     db = Session()
     try:
-        db.execute("SET log_statement_stats = OFF;")
-        db.execute("SET log_duration = OFF;")
-        db.execute("SET log_connections = OFF;")
         yield db
     finally:
         db.close()


### PR DESCRIPTION
This pull request fixes the issue of unnecessary database configuration statements in the code. The statements "SET log_statement_stats = OFF;", "SET log_duration = OFF;", and "SET log_connections = OFF;" have been removed. This allows the api to run on AWS lightsail because these permissions are not allowed on there.