### PR TITLE
Fix router import in main.py

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -514,7 +514,7 @@ from .utils.gtfs_rt_swiftly import connect_to_swiftly, SWIFTLY_API_REALTIME, SWI
 
 connected_clients = 0
 
-@router.get("/ws/{agency_id}/{endpoint}/{route_codes}")
+@app.router.get("/ws/{agency_id}/{endpoint}/{route_codes}")
 async def dummy_websocket_endpoint(agency_id: str, endpoint: str, route_codes: Optional[str] = None):
     """
     Dummy HTTP endpoint for WebSocket documentation.


### PR DESCRIPTION
This pull request fixes the router import in the main.py file. The import statement has been updated from `@router.get` to `@app.router.get`. This ensures that the correct router is used for the WebSocket endpoint.