### PR TITLE
Add endpoint to get trip shape stop times data

### DIFF
--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -164,6 +164,7 @@ class TripShapeStopTimes(BaseModel):
     trip_id = Column(String, primary_key=True, index=True)
     start_time = Column(TIMESTAMP)
     end_time = Column(TIMESTAMP)
+    is_next_day = Column(Boolean)
     payload = Column(String)
 
 class RouteStopsGrouped(BaseModel):

--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Float,PrimaryKeyConstraint,JSON, join, ARRAY, inspect
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Float,PrimaryKeyConstraint,JSON, join, ARRAY, inspect, Time
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.dialects.postgresql import ARRAY
 
@@ -153,6 +153,18 @@ class RouteStops(Base):
     # latitude = Column(Float)
     # longitude = Column(Float)
     agency_id = Column(String)
+
+class TripShapeStopTimes(BaseModel):
+    __tablename__ = "trip_shape_stop_times"
+    route_code = Column(String, index=True)
+    day_type = Column(String, index=True)
+    direction_id = Column(Integer, index=True)
+    geometry = Column(Geometry(geometry_type='GEOMETRY', srid=4326))
+    agency_id = Column(String, index=True)
+    trip_id = Column(String, primary_key=True, index=True)
+    start_time = Column(Time)
+    end_time = Column(Time)
+    payload = Column(String)
 
 class RouteStopsGrouped(BaseModel):
     __tablename__ = "route_stops_grouped"

--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Float,PrimaryKeyConstraint,JSON, join, ARRAY, inspect, Time
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Float,PrimaryKeyConstraint,JSON, join, ARRAY, inspect, Time, TIMESTAMP
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.dialects.postgresql import ARRAY
 
@@ -162,8 +162,8 @@ class TripShapeStopTimes(BaseModel):
     geometry = Column(Geometry(geometry_type='GEOMETRY', srid=4326))
     agency_id = Column(String, index=True)
     trip_id = Column(String, primary_key=True, index=True)
-    start_time = Column(Time)
-    end_time = Column(Time)
+    start_time = Column(TIMESTAMP)
+    end_time = Column(TIMESTAMP)
     payload = Column(String)
 
 class RouteStopsGrouped(BaseModel):


### PR DESCRIPTION
This pull request adds a new endpoint to the API that allows users to retrieve trip shape stop times data by route code, day type, direction id, and time. The endpoint is implemented in the `get_trip_shape_stop_times` function in the API code.