### PR TITLE
Refactor get_data_from_many_fields_async function and add new API endpoint for trip departure times

### DIFF
--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -194,12 +194,18 @@ async def get_data_async(async_session: Session, model: Type[DeclarativeMeta], a
 
     return [item.to_dict() for item in data]
 
-
-async def get_data_from_many_fields_async(async_session: Session, model: Type[DeclarativeMeta], agency_id: str, fields: Optional[Dict[str, Any]] = None, cache_expiration: int = None):
+async def get_data_from_many_fields_async(
+    async_session: Session, 
+    model: Type[DeclarativeMeta], 
+    agency_id: str, 
+    fields: Optional[Dict[str, Any]] = None, 
+    cache_expiration: int = None,
+    geometry: bool = False
+):
     # Create a unique key for this query
     logging.info(f"Executing query for model={model}, agency_id={agency_id}, fields={fields}")
 
-    key = f"{model.__name__}:{agency_id}:{fields}"
+    key = f"{model.__name__}:{agency_id}:{fields}:{geometry}"
 
     # Create a new Redis connection for each function call
     redis = aioredis.from_url(Config.REDIS_URL, socket_connect_timeout=5)

--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Float,PrimaryKeyConstraint,JSON, join, ARRAY, inspect, Time, TIMESTAMP
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Float,PrimaryKeyConstraint,JSON, join, inspect, Time, TIMESTAMP
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.dialects.postgresql import ARRAY
 
@@ -167,14 +167,29 @@ class TripShapeStopTimes(BaseModel):
     is_next_day = Column(Boolean)
     payload = Column(String)
 
+class TripDepartureTimes(BaseModel):
+    __tablename__ = "trip_departure_times"
+
+    trip_id = Column(String, primary_key=True, index=True)
+    route_code = Column(String)
+    agency_id = Column(String)
+    day_type = Column(String)
+    direction_id = Column(Integer)
+    shape_id = Column(String)
+    start_time = Column(Time)
+    end_time = Column(Time)
+    stops = Column(ARRAY(String))
+    departure_times = Column(ARRAY(String))
+    is_next_day = Column(Boolean)
+
 class RouteStopsGrouped(BaseModel):
     __tablename__ = "route_stops_grouped"
     route_code = Column(String,primary_key=True, index=True)
-    payload = Column(JSON)
-    agency_id = Column(String)
-    direction_id = Column(Integer)
-    day_type = Column(String)
-    shape_direction = Column(Geometry('LINESTRING', srid=4326))
+    # payload = Column(JSON)
+    # agency_id = Column(String)
+    # # direction_id = Column(Integer)
+    # day_type = Column(String)
+    # shape_direction = Column(Geometry('LINESTRING', srid=4326))
     # shape_direction_0 = Column(Geometry('LINESTRING', srid=4326))
     # shape_direction_1 = Column(Geometry('LINESTRING', srid=4326))
 


### PR DESCRIPTION
This pull request refactors the `get_data_from_many_fields_async` function in order to add a new API endpoint for retrieving trip departure times. The function now accepts an additional parameter `geometry` and includes it in the Redis key. The API endpoint `get_trip_departure_times` has been added to retrieve trip departure times based on route code, direction id, and day type.