### PR TITLE
Fix direction_id parameter validation

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -872,7 +872,7 @@ from geojson import LineString
 async def route_details_endpoint(
     agency_id: str, 
     route_code: str, 
-    direction_id: DirectionId = Query(...), 
+    direction_id: int = Query(..., ge=0, le=1),
     day_type: DayType = Query(...), 
     time: str = Query(...),  
     num_results: int = Query(3, ge=1),


### PR DESCRIPTION
This pull request fixes the validation of the direction_id parameter in the route_details_endpoint function. The direction_id parameter is now expected to be an integer between 0 and 1. This ensures that only valid direction IDs are accepted.