### PR TITLE
Refactor get_route_details and get_stop_times_by_route_code_and_agency functions

### DIFF
--- a/fastapi/app/crud.py
+++ b/fastapi/app/crud.py
@@ -819,7 +819,7 @@ async def get_stop_times_by_trip_id_and_time_range_async(
     # Create the query
     stmt = (
         select(model)
-        .join(models.Stops, models.Stops.stop_id == model.stop_id_cleaned)
+        .join(models.Stops, models.Stops.stop_id == model.stop_id_clean)
         .where(and_(*[cond[1] for cond in conditions]))
         .order_by(model.stop_sequence)  # Order by stop_sequence
     )
@@ -833,7 +833,7 @@ async def get_stop_times_by_trip_id_and_time_range_async(
     stop_times_grouped = {}
     for stop_time in stop_times:
         # Get the stop_name from the Stops model
-        stop = await async_session.execute(select(models.Stops).where(models.Stops.stop_id == stop_time.stop_id_cleaned))
+        stop = await async_session.execute(select(models.Stops).where(models.Stops.stop_id == stop_time.stop_id_clean))
         stop = stop.scalars().first()
         stop_name = stop.stop_name if stop else "Unknown"
         if stop_name not in stop_times_grouped:

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -903,20 +903,24 @@ async def get_calendar_dates_from_db(db: Session = Depends(get_db)):
     calendar_dates = jsonable_encoder(result)
     return JSONResponse(content={"calendar_dates":calendar_dates})
 
-@app.get("/{agency_id}/stop_times/route_code/{route_code}",tags=["Static data"],response_model=Page[schemas.StopTimes])
-async def get_stop_times_by_route_code_and_agency(agency_id: AgencyIdEnum,route_code, db: Session = Depends(get_db)):
-    result = crud.get_stop_times_by_route_code(db,route_code,agency_id.value)
+@app.get("/{agency_id}/stop_times/route_code/{route_code}",tags=["Static data"])
+async def get_stop_times_by_route_code_and_agency(agency_id: AgencyIdEnum, route_code, async_db: AsyncSession = Depends(get_async_db)):
+    result = await crud.get_data_async(async_db, models.StopTimes, agency_id.value, 'route_code', route_code)
     return result
 
-
-@app.get("/{agency_id}/stop_times/trip_id/{trip_id}",tags=["Static data"],response_model=Page[schemas.StopTimes])
-async def get_stop_times_by_trip_id_and_agency(agency_id: AgencyIdEnum,trip_id, db: Session = Depends(get_db)):
-    result = crud.get_stop_times_by_trip_id(db,trip_id,agency_id.value)
+@app.get("/{agency_id}/stop_times/trip_id/{trip_id}",tags=["Static data"])
+async def get_stop_times_by_trip_id_and_agency(agency_id: AgencyIdEnum,trip_id, async_db: AsyncSession = Depends(get_async_db)):
+    if trip_id == 'list':
+        result = await crud.get_list_of_unique_values_async(async_db, models.StopTimes, agency_id.value, 'trip_id')
+    elif trip_id == 'all':
+        result = await crud.get_all_data_async(async_db, models.StopTimes, agency_id.value)
+    else:
+        result = await crud.get_data_async(async_db, models.StopTimes, agency_id.value, 'trip_id', trip_id)
     return result
 
 @app.get("/{agency_id}/stops/{stop_id}",tags=["Static data"])
-async def get_stops(agency_id: AgencyIdEnum,stop_id, db: Session = Depends(get_db)):
-    result = crud.get_stops_id(db,stop_id,agency_id.value)
+async def get_stops(agency_id: AgencyIdEnum, stop_id, db: AsyncSession = Depends(get_async_db)):
+    result = await crud.get_stops_id(db, stop_id, agency_id.value)
     return result
 
 @app.get("/{agency_id}/trips/{trip_id}",tags=["Static data"])

--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -158,6 +158,8 @@ class RouteStops(Base):
     # latitude = Column(Float)
     # longitude = Column(Float)
     agency_id = Column(String)
+    def to_dict(self):
+        return {c.key: getattr(self, c.key) for c in inspect(self).mapper.column_attrs}
 
 class TripShapeStopTimes(BaseModel):
     __tablename__ = "trip_shape_stop_times"
@@ -188,6 +190,8 @@ class TripShapes(Base):
     shape_id = Column(String, primary_key=True, index=True)
     geometry = Column(Geometry('LINESTRING', srid=4326))
     agency_id = Column(String)
+    def to_dict(self):
+        return {c.key: getattr(self, c.key) for c in inspect(self).mapper.column_attrs}
 
 class Shapes(Base):
     __tablename__ = "shapes"
@@ -198,7 +202,8 @@ class Shapes(Base):
     geometry = Column(Geometry('POINT', srid=4326))
     shape_pt_sequence = Column(Integer)
     agency_id = Column(String)
-    
+    def to_dict(self):
+        return {c.key: getattr(self, c.key) for c in inspect(self).mapper.column_attrs}    
 
 class Trips(Base):
     __tablename__ = "trips"
@@ -211,6 +216,8 @@ class Trips(Base):
     shape_id = Column(String)
     trip_id_event = Column(String)
     agency_id = Column(String)
+    def to_dict(self):
+        return {c.key: getattr(self, c.key) for c in inspect(self).mapper.column_attrs}
 
 class TripShapeStops(Base):
     __tablename__ = "trip_shape_stops"

--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -66,7 +66,7 @@ class StopTimes(BaseModel):
     departure_time_clean = Column(Time)
     is_next_day = Column(Boolean)
     stop_id = Column(Integer, index=True)
-    stop_id_cleaned = Column(String)
+    stop_id_clean = Column(String)
     stop_sequence = Column(Integer,primary_key=True, index=True)
     stop_headsign = Column(String)
     pickup_type = Column(Integer)


### PR DESCRIPTION
This pull request refactors the get_route_details function in crud.py and the get_route_details endpoint. it is going from:


```json
{
  "stop_times": [
    [
      "De Soto / Burbank",
      [
        "21:15:00",
        "21:35:00",
        "21:55:00"
      ],
      "6010003_DEC23"
    ],
    [
      "Burbank / Warner Ranch",
      [
        "21:16:00"
      ],
      "6010003_DEC23"
    ],
```
to
```json
{
  "stop_times": [
    [
      "De Soto / Burbank",
      {
        "times": [
          "21:15:00"
        ],
        "shape_id": "6010001_DEC23"
      }
    ],
    [
      "De Soto / Burbank",
      {
        "times": [
          "21:35:00",
          "21:55:00",
        ],
        "shape_id": "6010003_DEC23"
      }
    ],
```
with more clearly labelled results.